### PR TITLE
optimize package.min.js generation

### DIFF
--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -113,7 +113,7 @@ func main() {
 		results := make(chan *outputPackage, numJobs)
 
 		// spawn workers
-		for w := 1; w <= runtime.NumCPU(); w++ {
+		for w := 1; w <= runtime.NumCPU()*10; w++ {
 			go generatePackageWorker(jobs, results)
 		}
 

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -85,16 +85,14 @@ func main() {
 		fmt.Println("Running in debug mode")
 	}
 
-	ctx := context.Background()
-
-	bkt, err := cloudstorage.GetAssetsBucket(ctx)
-	util.Check(err)
-
-	obj := bkt.Object("package.min.js")
-
 	if subcommand == "set" {
+		ctx := context.Background()
+		bkt, err := cloudstorage.GetAssetsBucket(ctx)
+		util.Check(err)
+		obj := bkt.Object("package.min.js")
+
 		w := obj.NewWriter(ctx)
-		_, err := io.Copy(w, os.Stdin)
+		_, err = io.Copy(w, os.Stdin)
 		util.Check(err)
 		util.Check(w.Close())
 		util.Check(obj.ACL().Set(ctx, storage.AllUsers, storage.RoleReader))
@@ -115,7 +113,7 @@ func main() {
 		results := make(chan *outputPackage, numJobs)
 
 		// spawn workers
-		for w := 1; w <= runtime.NumCPU()*10; w++ {
+		for w := 1; w <= runtime.NumCPU(); w++ {
 			go generatePackageWorker(jobs, results)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/karrick/godirwalk v1.15.6
 	github.com/pachyderm/ohmyglob v0.0.0-20190808212558-a8e61fd76805
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdl
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/karrick/godirwalk v1.15.6 h1:Yf2mmR8TJy+8Fa0SuQVto5SYap6IF7lNVX4Jdl8G1qA=
+github.com/karrick/godirwalk v1.15.6/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -127,7 +127,7 @@ func (p *Package) AllFiles(version string) []string {
 	out := make([]string, 0)
 
 	absPath := path.Join(p.Path(), version)
-	out = append(out, util.ListFilesGlob(p.ctx, absPath, "**")...)
+	out = append(out, util.ListFilesInVersion(p.ctx, absPath)...)
 
 	return out
 }

--- a/util/fileglob.go
+++ b/util/fileglob.go
@@ -83,16 +83,6 @@ func ListFilesInVersion(ctx context.Context, base string) []string {
 		FollowSymbolicLinks: true,
 	})
 
-	// Uncomment if you want to attempt the legacy version if non-nil error,
-	// for example, at least one package (history version 3.0.0-1) has
-	// symlink js files that link to themselves due to case
-	// insensitivity on some operating systems (macOS), causing an error
-
-	// if err != nil {
-	// 	Debugf(ctx, "list files in version: %s", err)
-	// 	return ListFilesGlob(ctx, base, "**")
-	// }
-
 	Check(err)
 	return list
 }

--- a/util/fileglob.go
+++ b/util/fileglob.go
@@ -8,12 +8,26 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/karrick/godirwalk"
 )
 
+// ListFilesGlob is the legacy, slower version that uses
+// the node glob tool found here: https://github.com/cdnjs/glob
 func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
+	list := make([]string, 0)
+
+	// Currently not ignoring hidden files, uncomment out to compare with ListFilesInVersion directly
+
+	// // check if the version is hidden
+	// if isHidden(base) {
+	// 	Debugf(ctx, "ignoring hidden version %s", base)
+	// 	return list
+	// }
+
 	if _, err := os.Stat(base); os.IsNotExist(err) {
 		Debugf(ctx, "match %s in %s but doesn't exists", pattern, base)
-		return []string{}
+		return list
 	}
 
 	cmd := exec.Command(path.Join(GetBotBasePath(), "glob", "index.js"), pattern)
@@ -27,13 +41,56 @@ func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
 		Check(err)
 	}
 
-	list := make([]string, 0)
-
 	for _, line := range strings.Split(out.String(), "\n") {
 		if strings.Trim(line, " ") != "" {
 			list = append(list, line)
 		}
 
+	}
+	return list
+}
+
+// Determines if a file path contains a hidden file or directory.
+// Either it starts with . or or contains '/.' to be considered hidden.
+func isHidden(fp string) bool {
+	return strings.HasPrefix(fp, ".") || strings.Contains(fp, "/.")
+}
+
+// ListFilesInVersion is the new, optimized version of ListFilesGlob created for
+// package generation. It lists all of the files within a particular cdnjs package version in
+// the same manner as ListFilesGlob with a '**' glob pattern.
+// Note that hidden cdnjs versions and hidden files/directories are ignored.
+// It utilizes the fast godirwalk library found here: https://github.com/karrick/godirwalk
+func ListFilesInVersion(ctx context.Context, base string) []string {
+	list := make([]string, 0)
+
+	// check if the version is hidden
+	if isHidden(base) {
+		Debugf(ctx, "ignoring hidden version %s", base)
+		return list
+	}
+
+	// walk the files recursively within the cdnjs package version directory
+	err := godirwalk.Walk(base, &godirwalk.Options{
+		Callback: func(fp string, de *godirwalk.Dirent) error {
+			// trim a full path to a path relative to the base directory (inside package version dir)
+			// trim any leading '/' for consistency with legacy ListFilesGlob implementation
+			fp = strings.TrimLeft(strings.TrimPrefix(fp, base), "/")
+			// path must not be a directory, not be hidden, and not be empty
+			if !de.IsDir() && !isHidden(fp) && fp != "" {
+				list = append(list, fp)
+			}
+			return nil
+		},
+		FollowSymbolicLinks: true,
+	})
+
+	// if non-nil error, attempt to try with the legacy version
+	// for example, at least one package (history) has
+	// symlink js files that link to themselves due to case
+	// insensitivity on some operating systems, causing an error
+	if err != nil {
+		return ListFilesGlob(ctx, base, "**")
 	}
 	return list
 }

--- a/util/fileglob.go
+++ b/util/fileglob.go
@@ -17,13 +17,11 @@ import (
 func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
 	list := make([]string, 0)
 
-	// Currently not ignoring hidden files, uncomment out to compare with ListFilesInVersion directly
-
-	// // check if the version is hidden
-	// if isHidden(base) {
-	// 	Debugf(ctx, "ignoring hidden version %s", base)
-	// 	return list
-	// }
+	// check if the version is hidden
+	if isHidden(base) {
+		Debugf(ctx, "ignoring hidden version %s", base)
+		return list
+	}
 
 	if _, err := os.Stat(base); os.IsNotExist(err) {
 		Debugf(ctx, "match %s in %s but doesn't exists", pattern, base)
@@ -51,7 +49,7 @@ func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
 }
 
 // Determines if a file path contains a hidden file or directory.
-// Either it starts with . or or contains '/.' to be considered hidden.
+// Either it starts with . or contains '/.' to be considered hidden.
 func isHidden(fp string) bool {
 	return strings.HasPrefix(fp, ".") || strings.Contains(fp, "/.")
 }
@@ -85,12 +83,16 @@ func ListFilesInVersion(ctx context.Context, base string) []string {
 		FollowSymbolicLinks: true,
 	})
 
-	// if non-nil error, attempt to try with the legacy version
-	// for example, at least one package (history) has
+	// Uncomment if you want to attempt the legacy version if non-nil error,
+	// for example, at least one package (history version 3.0.0-1) has
 	// symlink js files that link to themselves due to case
-	// insensitivity on some operating systems, causing an error
-	if err != nil {
-		return ListFilesGlob(ctx, base, "**")
-	}
+	// insensitivity on some operating systems (macOS), causing an error
+
+	// if err != nil {
+	// 	Debugf(ctx, "list files in version: %s", err)
+	// 	return ListFilesGlob(ctx, base, "**")
+	// }
+
+	Check(err)
 	return list
 }


### PR DESCRIPTION
By removing the [index.js glob tool](https://github.com/cdnjs/glob) from the package generation and replacing it with a Go implementation, speed has increased at least 10 fold!

The library used for a file walk is [godirwalk](https://github.com/karrick/godirwalk) since it will navigate within symlink directories, while the native [filepath package](https://golang.org/pkg/path/filepath/) was not able to do this. Also, `godirwalk` is [ apparently much faster ](https://boyter.org/2018/03/quick-comparison-go-file-walk-implementations/). The library has been added to `go.mod` and `go.sum`.

For now, the `ListFilesGlob` function will remain for the other programs (bot, etc) as the new function `ListFilesInVersion` has only been tested for the package generation, handling all necessary corner cases. Through testing, the files included by `ListFilesGlob` included all file types except directories, except for hidden files. However, hidden cdnjs package versions were navigated into, but any hidden subdirectories were ignored. The new function `ListFilesInVersion` will ignore these hidden cdnjs package versions looking forward.