### PR TITLE
Limit file size to 10MB

### DIFF
--- a/cmd/autoupdate/README.md
+++ b/cmd/autoupdate/README.md
@@ -1,1 +1,4 @@
 # Autoupdate
+
+## -no-update
+If the flag is set, the autoupdater will not commit or push to git. This is used for local testing purposes.

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -38,10 +38,12 @@ type newVersionToCommit struct {
 }
 
 func main() {
+	var noUpdate bool
+	flag.BoolVar(&noUpdate, "no-update", false, "if set, the autoupdater will not commit or push to git")
 	flag.Parse()
 
 	if util.IsDebug() {
-		fmt.Println("Running in debug mode")
+		fmt.Println("Running in debug mode", noUpdate)
 	}
 
 	util.UpdateGitRepo(context.Background(), CDNJS_PATH)
@@ -66,10 +68,14 @@ func main() {
 			}
 		}
 
-		commitNewVersions(ctx, newVersionsToCommit, f)
+		if !noUpdate {
+			commitNewVersions(ctx, newVersionsToCommit, f)
+		}
 	}
 
-	packages.GitPush(context.Background(), CDNJS_PATH)
+	if !noUpdate {
+		packages.GitPush(context.Background(), CDNJS_PATH)
+	}
 }
 
 func packageJsonToString(packageJson map[string]interface{}) ([]byte, error) {

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -26,7 +26,9 @@ var (
 )
 
 func getPackages(ctx context.Context) []string {
-	return util.ListFilesGlob(ctx, PACKAGES_PATH, "*/*.json")
+	list, err := util.ListFilesGlob(ctx, PACKAGES_PATH, "*/*.json")
+	util.Check(err)
+	return list
 }
 
 type newVersionToCommit struct {

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -4,8 +4,8 @@ Tools for our CI.
 
 ## `lint`
 
-Check that a package is correctly configured.
+Checks that a package is correctly configured based on its JSON.
 
 ## `show-files`
 
-Output how many package files match for a number of latest npm/git versions.
+Output how many package files match and whether they will be ignored for a number of latest npm/git versions.

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -5,3 +5,7 @@ Tools for our CI.
 ## `lint`
 
 Check that a package is correctly configured.
+
+## `show-files`
+
+Output how many package files match for a number of latest npm/git versions.

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -264,6 +264,9 @@ func lintPackage(pckgPath string) {
 		panic("unexpected package json path")
 	}
 
+	// used to determine if there is at least one file
+	var atLeastOneFile bool
+
 	// check file sizes
 	versionDir := path.Join(pckgPath[:len(pckgPath)-len(pkgJSON)], pckg.Version)
 	for _, fileMap := range pckg.NpmFileMap {
@@ -292,10 +295,16 @@ func lintPackage(pckgPath string) {
 				if size > util.MAX_FILE_SIZE {
 					warn(ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
 				} else {
+					atLeastOneFile = true
 					util.Debugf(ctx, fp, "ok")
 				}
 			}
 		}
+	}
+
+	// fail if not least one file
+	if !atLeastOneFile {
+		err(ctx, "all files ignored due to size")
 	}
 
 }

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -296,7 +296,7 @@ func lintPackage(pckgPath string) {
 					warn(ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
 				} else {
 					atLeastOneFile = true
-					util.Debugf(ctx, fp, "ok")
+					util.Debugf(ctx, fp+" ok")
 				}
 			}
 		}

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -150,13 +150,13 @@ func showFiles(pckgPath string) {
 		}
 
 		// print info for the first version
-		firstNpmVersion := gitVersions[0]
+		firstGitVersion := gitVersions[0]
 		{
 			filesToCopy := pckg.NpmFilesFrom(packageGitDir)
 
 			if len(filesToCopy) == 0 {
 				errormsg := ""
-				errormsg += fmt.Sprintf("No files will be published for version %s.\n", firstNpmVersion.Version)
+				errormsg += fmt.Sprintf("No files will be published for version %s.\n", firstGitVersion.Version)
 
 				for _, filemap := range pckg.NpmFileMap {
 					for _, pattern := range filemap.Files {
@@ -299,8 +299,6 @@ func lintPackage(pckgPath string) {
 		for _, fileMap := range pckg.NpmFileMap {
 			for _, pattern := range fileMap.Files {
 				basePath := path.Join(tmpDir, fileMap.BasePath)
-
-				fmt.Println("TMPDIR", tmpDir)
 
 				// find files that match glob
 				pkgCtx := util.ContextWithName(basePath)

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -334,10 +334,10 @@ func lintPackage(pckgPath string) {
 					size := info.Size()
 					if size > util.MAX_FILE_SIZE {
 						warn(ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
-					} else {
-						atLeastOneFile = true
-						util.Debugf(ctx, fp+" ok")
+						continue
 					}
+					atLeastOneFile = true
+					util.Debugf(ctx, fp+" ok")
 				}
 			}
 		}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -127,7 +127,9 @@ func (p *Package) AllFiles(version string) []string {
 	out := make([]string, 0)
 
 	absPath := path.Join(p.Path(), version)
-	out = append(out, util.ListFilesInVersion(p.ctx, absPath)...)
+	list, err := util.ListFilesInVersion(p.ctx, absPath)
+	util.Check(err)
+	out = append(out, list...)
 
 	return out
 }

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -117,7 +117,7 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 
 			// find files that match glob
 			list, err := util.ListFilesGlob(p.ctx, basePath, pattern)
-			util.Check(err)
+			util.Check(err) // should have already run before in checker so panic if glob invalid
 
 			for _, f := range list {
 				fp := path.Join(basePath, f)
@@ -131,6 +131,7 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 				info, staterr := os.Stat(fp)
 				if staterr != nil {
 					util.Debugf(p.ctx, "stat: "+staterr.Error())
+					// TODO: warn if in checker err(ctx, "stat: "+staterr.Error())
 					continue
 				}
 
@@ -138,6 +139,7 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 				size := info.Size()
 				if size > util.MAX_FILE_SIZE {
 					util.Debugf(p.ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
+					// TODO: warn if in checker warn(ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
 					continue
 				}
 
@@ -149,11 +151,6 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 				})
 			}
 		}
-	}
-
-	// check if any results
-	if len(out) == 0 {
-		util.Debugf(p.ctx, "glob(s) found no matching files")
 	}
 
 	return out

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -110,7 +110,10 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 		for _, pattern := range fileMap.Files {
 			basePath := path.Join(base, fileMap.BasePath)
 
-			for _, f := range util.ListFilesGlob(p.ctx, basePath, pattern) {
+			list, err := util.ListFilesGlob(p.ctx, basePath, pattern)
+			util.Check(err)
+
+			for _, f := range list {
 				out = append(out, NpmFileMoveOp{
 					From: path.Join(fileMap.BasePath, f),
 					To:   f,

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -2,6 +2,8 @@ package packages
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path"
 	"sort"
 
@@ -101,30 +103,57 @@ type NpmFileMoveOp struct {
 	To   string
 }
 
-// List files that match the npm glob pattern in the `base` directory
+// NpmFilesFrom lists files that match the npm glob pattern in the `base` directory
 // Returns a struct that represent the move semantics
 func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 	out := make([]NpmFileMoveOp, 0)
+
+	// map used to determine if a file path has already been processed
+	seen := make(map[string]bool)
 
 	for _, fileMap := range p.NpmFileMap {
 		for _, pattern := range fileMap.Files {
 			basePath := path.Join(base, fileMap.BasePath)
 
+			// find files that match glob
 			list, err := util.ListFilesGlob(p.ctx, basePath, pattern)
 			util.Check(err)
 
 			for _, f := range list {
+				fp := path.Join(basePath, f)
 
-				// TODO: check file size, if > util.MAX_FILE_SIZE
-				// then output warning and ignore.
-				// Will be similar to main.go's function.
+				// check if file has been processed before
+				if _, ok := seen[fp]; ok {
+					continue
+				}
+				seen[fp] = true
 
+				info, staterr := os.Stat(fp)
+				if staterr != nil {
+					util.Debugf(p.ctx, "stat: "+staterr.Error())
+					continue
+				}
+
+				// warn for files with sizes exceeding max file size
+				size := info.Size()
+				if size > util.MAX_FILE_SIZE {
+					util.Debugf(p.ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
+					continue
+				}
+
+				// file is ok
+				util.Debugf(p.ctx, fp+" ok")
 				out = append(out, NpmFileMoveOp{
 					From: path.Join(fileMap.BasePath, f),
 					To:   f,
 				})
 			}
 		}
+	}
+
+	// check if any results
+	if len(out) == 0 {
+		util.Debugf(p.ctx, "glob(s) found no matching files")
 	}
 
 	return out

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -114,6 +114,11 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 			util.Check(err)
 
 			for _, f := range list {
+
+				// TODO: check file size, if > util.MAX_FILE_SIZE
+				// then output warning and ignore.
+				// Will be similar to main.go's function.
+
 				out = append(out, NpmFileMoveOp{
 					From: path.Join(fileMap.BasePath, f),
 					To:   f,

--- a/util/const.go
+++ b/util/const.go
@@ -7,5 +7,5 @@ const (
 	IMPORT_ALL_MAX_VERSIONS = 10
 
 	// Maximum file size in bytes accepted by cdnjs.
-	MAX_FILE_SIZE int = 1e7
+	MAX_FILE_SIZE int64 = 1e7
 )

--- a/util/const.go
+++ b/util/const.go
@@ -3,9 +3,13 @@ package util
 const (
 	// When no versions exist in cdnjs and we are trying to import all of them,
 	// limit it to the a few last versions to avoid publishing too many outdated
-	// versions
+	// versions.
 	IMPORT_ALL_MAX_VERSIONS = 10
 
 	// Maximum file size in bytes accepted by cdnjs.
 	MAX_FILE_SIZE int64 = 1e7
+
+	// Minimum number of monthly downloads from npm needed
+	// for a library to be accepted into cdnjs.
+	MIN_NPM_MONTHLY_DOWNLOADS = 800
 )

--- a/util/const.go
+++ b/util/const.go
@@ -5,4 +5,7 @@ const (
 	// limit it to the a few last versions to avoid publishing too many outdated
 	// versions
 	IMPORT_ALL_MAX_VERSIONS = 10
+
+	// Maximum file size in bytes accepted by cdnjs.
+	MAX_FILE_SIZE int = 1e7
 )

--- a/util/fileglob.go
+++ b/util/fileglob.go
@@ -14,18 +14,18 @@ import (
 
 // ListFilesGlob is the legacy, slower version that uses
 // the node glob tool found here: https://github.com/cdnjs/glob
-func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
+func ListFilesGlob(ctx context.Context, base string, pattern string) ([]string, error) {
 	list := make([]string, 0)
 
 	// check if the version is hidden
 	if isHidden(base) {
 		Debugf(ctx, "ignoring hidden version %s", base)
-		return list
+		return list, nil
 	}
 
 	if _, err := os.Stat(base); os.IsNotExist(err) {
 		Debugf(ctx, "match %s in %s but doesn't exists", pattern, base)
-		return list
+		return list, nil
 	}
 
 	cmd := exec.Command(path.Join(GetBotBasePath(), "glob", "index.js"), pattern)
@@ -36,7 +36,7 @@ func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
 	err := cmd.Run()
 	if err != nil {
 		fmt.Printf("%s: %s\n", err, out.String())
-		Check(err)
+		return list, err
 	}
 
 	for _, line := range strings.Split(out.String(), "\n") {
@@ -45,7 +45,7 @@ func ListFilesGlob(ctx context.Context, base string, pattern string) []string {
 		}
 
 	}
-	return list
+	return list, nil
 }
 
 // Determines if a file path contains a hidden file or directory.

--- a/util/fileglob.go
+++ b/util/fileglob.go
@@ -59,13 +59,13 @@ func isHidden(fp string) bool {
 // the same manner as ListFilesGlob with a '**' glob pattern.
 // Note that hidden cdnjs versions and hidden files/directories are ignored.
 // It utilizes the fast godirwalk library found here: https://github.com/karrick/godirwalk
-func ListFilesInVersion(ctx context.Context, base string) []string {
+func ListFilesInVersion(ctx context.Context, base string) ([]string, error) {
 	list := make([]string, 0)
 
 	// check if the version is hidden
 	if isHidden(base) {
 		Debugf(ctx, "ignoring hidden version %s", base)
-		return list
+		return list, nil
 	}
 
 	// walk the files recursively within the cdnjs package version directory
@@ -83,6 +83,5 @@ func ListFilesInVersion(ctx context.Context, base string) []string {
 		FollowSymbolicLinks: true,
 	})
 
-	Check(err)
-	return list
+	return list, err
 }


### PR DESCRIPTION
File size limited to 1e7 bytes (10MB) maximum.

**Checker:**
If a file is over 10MB, `lint` will warn that this file will be ignored. 
If there are no valid files,`lint` will give an error.

Now, `lint` gives an error if the input json file does not contain an `autoupdate` field.
Both `show-files` and `lint` do not display duplicate files. For example, if multiple globs have file overlap/are repeated, like in this [test file](https://github.com/tc80/test-cdnjs-pkg/blob/master/package_all_ignored_repeated_glob.json), the files will only be processed once to avoid potential output spam. 

**Autoupdate:**
The bot will now log and ignore files over 10MB.
The bot now has a flag for local testing `-no-update` which is used to prevent any git commits/pushes.
Similar to the checker, the bot will not process duplicate files.
