### PR TITLE
Warning differently for checker/autoupdater

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	for _, f := range getPackages(context.Background()) {
 		ctx := util.ContextWithName(f)
-		pckg, err := packages.ReadPackageJSON(ctx, path.Join(PACKAGES_PATH, f))
+		pckg, err := packages.ReadPackageJSON(ctx, path.Join(PACKAGES_PATH, f), false)
 		util.Check(err)
 
 		var newVersionsToCommit []newVersionToCommit

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -23,6 +23,9 @@ var (
 	BASE_PATH     = util.GetEnv("BOT_BASE_PATH")
 	PACKAGES_PATH = path.Join(BASE_PATH, "packages", "packages")
 	CDNJS_PATH    = path.Join(BASE_PATH, "cdnjs")
+
+	// initialize standard debug logger
+	logger = util.GetStandardLogger()
 )
 
 func getPackages(ctx context.Context) []string {
@@ -50,8 +53,11 @@ func main() {
 	util.UpdateGitRepo(context.Background(), PACKAGES_PATH)
 
 	for _, f := range getPackages(context.Background()) {
-		ctx := util.ContextWithName(f)
-		pckg, err := packages.ReadPackageJSON(ctx, path.Join(PACKAGES_PATH, f), false)
+
+		// create context with file path prefix, standard debug logger
+		ctx := util.ContextWithEntries(util.GetStandardEntries(f, logger)...)
+
+		pckg, err := packages.ReadPackageJSON(ctx, path.Join(PACKAGES_PATH, f))
 		util.Check(err)
 
 		var newVersionsToCommit []newVersionToCommit

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -53,7 +53,6 @@ func main() {
 	util.UpdateGitRepo(context.Background(), PACKAGES_PATH)
 
 	for _, f := range getPackages(context.Background()) {
-
 		// create context with file path prefix, standard debug logger
 		ctx := util.ContextWithEntries(util.GetStandardEntries(f, logger)...)
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/cdnjs/tools/git"
 	"github.com/cdnjs/tools/npm"
@@ -268,20 +267,12 @@ func lintPackage(pckgPath string) {
 }
 
 func err(ctx context.Context, s string) {
-	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
-		fmt.Printf("::error file=%s,line=1,col=1::%s\n", prefix, escapeGitHub(s))
-	} else {
-		panic("unreachable")
-	}
+	util.CheckerErr(ctx, s)
 	errCount++
 }
 
 func warn(ctx context.Context, s string) {
-	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
-		fmt.Printf("::warning file=%s,line=1,col=1::%s\n", prefix, escapeGitHub(s))
-	} else {
-		panic("unreachable")
-	}
+	util.CheckerWarn(ctx, s)
 }
 
 func shouldBeEmpty(name string) string {
@@ -290,11 +281,4 @@ func shouldBeEmpty(name string) string {
 
 func shouldNotBeEmpty(name string) string {
 	return fmt.Sprintf("%s should be specified", name)
-}
-
-func escapeGitHub(s string) string {
-	s = strings.ReplaceAll(s, "%", "%25")
-	s = strings.ReplaceAll(s, "\n", "%0A")
-	s = strings.ReplaceAll(s, "\r", "%0D")
-	return s
 }

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -54,7 +54,6 @@ func main() {
 }
 
 func showFiles(pckgPath string) {
-
 	// create context with file path prefix, checker logger
 	ctx := util.ContextWithEntries(util.GetCheckerEntries(pckgPath, logger)...)
 
@@ -211,7 +210,6 @@ func makeGlobDebugLink(glob string, dir string) string {
 }
 
 func lintPackage(pckgPath string) {
-
 	// create context with file path prefix, checker logger
 	ctx := util.ContextWithEntries(util.GetCheckerEntries(pckgPath, logger)...)
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -56,7 +56,7 @@ func main() {
 
 func showFiles(pckgPath string) {
 	ctx := util.ContextWithName(pckgPath)
-	pckg, readerr := packages.ReadPackageJSON(ctx, pckgPath)
+	pckg, readerr := packages.ReadPackageJSON(ctx, pckgPath, true)
 	if readerr != nil {
 		err(ctx, readerr.Error())
 		return
@@ -213,7 +213,7 @@ func lintPackage(pckgPath string) {
 
 	util.Debugf(ctx, "Linting %s...\n", pckgPath)
 
-	pckg, readerr := packages.ReadPackageJSON(ctx, pckgPath)
+	pckg, readerr := packages.ReadPackageJSON(ctx, pckgPath, true)
 	if readerr != nil {
 		err(ctx, readerr.Error())
 		return

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -20,6 +20,11 @@ import (
 	"cloud.google.com/go/storage"
 )
 
+var (
+	// initialize standard debug logger
+	logger = util.GetStandardLogger()
+)
+
 func encodeJson(packages []*outputPackage) (string, error) {
 	out := struct {
 		Packages []*outputPackage `json:"packages"`
@@ -36,9 +41,11 @@ func encodeJson(packages []*outputPackage) (string, error) {
 
 func generatePackageWorker(jobs <-chan string, results chan<- *outputPackage) {
 	for f := range jobs {
-		ctx := util.ContextWithName(f)
 
-		p, err := packages.ReadPackageJSON(ctx, f, false)
+		// create context with file path prefix, standard debug logger
+		ctx := util.ContextWithEntries(util.GetStandardEntries(f, logger)...)
+
+		p, err := packages.ReadPackageJSON(ctx, f)
 		if err != nil {
 			util.Printf(ctx, "error while processing package: %s\n", err)
 			results <- nil

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -41,7 +41,6 @@ func encodeJson(packages []*outputPackage) (string, error) {
 
 func generatePackageWorker(jobs <-chan string, results chan<- *outputPackage) {
 	for f := range jobs {
-
 		// create context with file path prefix, standard debug logger
 		ctx := util.ContextWithEntries(util.GetStandardEntries(f, logger)...)
 

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -38,7 +38,7 @@ func generatePackageWorker(jobs <-chan string, results chan<- *outputPackage) {
 	for f := range jobs {
 		ctx := util.ContextWithName(f)
 
-		p, err := packages.ReadPackageJSON(ctx, f)
+		p, err := packages.ReadPackageJSON(ctx, f, false)
 		if err != nil {
 			util.Printf(ctx, "error while processing package: %s\n", err)
 			results <- nil

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -2,7 +2,6 @@ package packages
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"sort"
@@ -138,7 +137,7 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 				// warn for files with sizes exceeding max file size
 				size := info.Size()
 				if size > util.MAX_FILE_SIZE {
-					util.Warnf(p.ctx, p.RunFromChecker, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
+					util.Warnf(p.ctx, p.RunFromChecker, "file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE)
 					continue
 				}
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -48,19 +48,20 @@ type Package struct {
 	// Cache list of versions for the package
 	versions []string
 
-	Title       string
-	Name        string
-	Description string
-	Version     string
-	Author      Author
-	Homepage    string
-	Keywords    []string
-	Repository  Repository
-	Filename    string
-	NpmName     *string
-	NpmFileMap  []FileMap
-	License     *License
-	Autoupdate  *Autoupdate
+	Title          string
+	Name           string
+	Description    string
+	Version        string
+	Author         Author
+	Homepage       string
+	Keywords       []string
+	Repository     Repository
+	Filename       string
+	NpmName        *string
+	NpmFileMap     []FileMap
+	License        *License
+	Autoupdate     *Autoupdate
+	RunFromChecker bool // if the program is run from the checker's main method
 }
 
 func stringInObject(key string, object map[string]interface{}) string {
@@ -130,16 +131,14 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 
 				info, staterr := os.Stat(fp)
 				if staterr != nil {
-					util.Debugf(p.ctx, "stat: "+staterr.Error())
-					// TODO: warn if in checker err(ctx, "stat: "+staterr.Error())
+					util.Warnf(p.ctx, p.RunFromChecker, "stat: "+staterr.Error())
 					continue
 				}
 
 				// warn for files with sizes exceeding max file size
 				size := info.Size()
 				if size > util.MAX_FILE_SIZE {
-					util.Debugf(p.ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
-					// TODO: warn if in checker warn(ctx, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
+					util.Warnf(p.ctx, p.RunFromChecker, fmt.Sprintf("file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE))
 					continue
 				}
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -47,20 +47,19 @@ type Package struct {
 	// Cache list of versions for the package
 	versions []string
 
-	Title          string
-	Name           string
-	Description    string
-	Version        string
-	Author         Author
-	Homepage       string
-	Keywords       []string
-	Repository     Repository
-	Filename       string
-	NpmName        *string
-	NpmFileMap     []FileMap
-	License        *License
-	Autoupdate     *Autoupdate
-	RunFromChecker bool // if the program is run from the checker's main method
+	Title       string
+	Name        string
+	Description string
+	Version     string
+	Author      Author
+	Homepage    string
+	Keywords    []string
+	Repository  Repository
+	Filename    string
+	NpmName     *string
+	NpmFileMap  []FileMap
+	License     *License
+	Autoupdate  *Autoupdate
 }
 
 func stringInObject(key string, object map[string]interface{}) string {
@@ -130,14 +129,14 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 
 				info, staterr := os.Stat(fp)
 				if staterr != nil {
-					util.Warnf(p.ctx, p.RunFromChecker, "stat: "+staterr.Error())
+					util.Warnf(p.ctx, "stat: "+staterr.Error())
 					continue
 				}
 
 				// warn for files with sizes exceeding max file size
 				size := info.Size()
 				if size > util.MAX_FILE_SIZE {
-					util.Warnf(p.ctx, p.RunFromChecker, "file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE)
+					util.Warnf(p.ctx, "file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE)
 					continue
 				}
 

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -11,7 +11,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
+// ReadPackageJSON parses a JSON file into a Package.
+// Note that runFromChecker is used in to determine if the program was run from
+// the checker's main method, which logs differently from the other programs.
+func ReadPackageJSON(ctx context.Context, file string, runFromChecker bool) (*Package, error) {
 	var jsondata map[string]interface{}
 
 	data, err := ioutil.ReadFile(file)
@@ -26,6 +29,7 @@ func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 
 	var p Package
 	p.ctx = ctx
+	p.RunFromChecker = runFromChecker
 
 	for key, value := range jsondata {
 		switch key {

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -12,9 +12,7 @@ import (
 )
 
 // ReadPackageJSON parses a JSON file into a Package.
-// Note that runFromChecker is used in to determine if the program was run from
-// the checker's main method, which logs differently from the other programs.
-func ReadPackageJSON(ctx context.Context, file string, runFromChecker bool) (*Package, error) {
+func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 	var jsondata map[string]interface{}
 
 	data, err := ioutil.ReadFile(file)
@@ -29,7 +27,6 @@ func ReadPackageJSON(ctx context.Context, file string, runFromChecker bool) (*Pa
 
 	var p Package
 	p.ctx = ctx
-	p.RunFromChecker = runFromChecker
 
 	for key, value := range jsondata {
 		switch key {

--- a/util/const.go
+++ b/util/const.go
@@ -6,8 +6,8 @@ const (
 	// versions.
 	IMPORT_ALL_MAX_VERSIONS = 10
 
-	// Maximum file size in bytes accepted by cdnjs.
-	MAX_FILE_SIZE int64 = 1e7
+	// Maximum file size in bytes accepted by cdnjs (10MiB).
+	MAX_FILE_SIZE int64 = 10485760
 
 	// Minimum number of monthly downloads from npm needed
 	// for a library to be accepted into cdnjs.

--- a/util/context.go
+++ b/util/context.go
@@ -4,6 +4,48 @@ import (
 	"context"
 )
 
-func ContextWithName(loggerPrefix string) context.Context {
-	return context.WithValue(context.Background(), "loggerPrefix", loggerPrefix)
+// ContextKey is the key type used for context.WithValue().
+type ContextKey int
+
+// ContextEntry represents a key-value entry for a context.
+type ContextEntry struct {
+	Key   ContextKey
+	Value interface{}
+}
+
+const (
+	// LoggerPrefix is the key to the string that is outputted first when logging.
+	// If the *log.Logger itself has a prefix set as well, the *log.Logger's
+	// prefix will be outputted before the LoggerPrefix.
+	//
+	// For example, the LoggerPrefix may represent a file name and
+	// the *log.Logger may have a prefix to represent the program entry point.
+	// As a result, when logging "hello world" from the program "main" and path "/usr",
+	// the output may look like "main /usr hello world".
+	LoggerPrefix ContextKey = iota
+
+	// Logger is the key for a *log.Logger.
+	Logger
+
+	// Debug is the LogFunc that is called when outputting a debug statement.
+	Debug
+
+	// Warn is the LogFunc that is called when outputting a warning.
+	Warn
+
+	// Err is the LogFunc that is called when outputting an error.
+	Err
+)
+
+// ContextWithEntries creates a context with a variadic number of key-value
+// entries. Internally, this context's root node is context.Background() and
+// a new context is created for each new key-value entry. While a single value
+// as a map may be more efficient, there are only a handful of potential ContextEntry
+// entries, so the complexity can be ignored.
+func ContextWithEntries(entries ...ContextEntry) context.Context {
+	parent := context.Background()
+	for _, entry := range entries {
+		parent = context.WithValue(parent, entry.Key, entry.Value)
+	}
+	return parent
 }

--- a/util/log.go
+++ b/util/log.go
@@ -2,8 +2,10 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 )
 
 var (
@@ -11,6 +13,7 @@ var (
 	logger = log.New(os.Stderr, "", flags)
 )
 
+// Printf uses the logger to log a formatted string.
 func Printf(ctx context.Context, format string, v ...interface{}) {
 	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
 		logger.Printf(prefix+": "+format, v...)
@@ -19,12 +22,50 @@ func Printf(ctx context.Context, format string, v ...interface{}) {
 	}
 }
 
+// Debugf calls Printf if the program is in DEBUG mode.
 func Debugf(ctx context.Context, format string, v ...interface{}) {
 	if IsDebug() {
 		Printf(ctx, format, v...)
 	}
 }
 
+// Warnf is used to output a warning, either to STDOUT in logger format for the CI checker
+// or STDERR for debugging.
+func Warnf(ctx context.Context, runFromChecker bool, format string, v ...interface{}) {
+	if runFromChecker {
+		CheckerWarn(ctx, fmt.Sprintf(format, v...))
+	} else {
+		Debugf(ctx, format, v...)
+	}
+}
+
+// CheckerErr outputs an error to STDOUT for the CI checker.
+func CheckerErr(ctx context.Context, s string) {
+	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
+		fmt.Printf("::error file=%s,line=1,col=1::%s\n", prefix, escapeGitHub(s))
+	} else {
+		panic("unreachable")
+	}
+}
+
+// CheckerWarn outputs a warning to STDOUT for the CI checker.
+func CheckerWarn(ctx context.Context, s string) {
+	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
+		fmt.Printf("::warning file=%s,line=1,col=1::%s\n", prefix, escapeGitHub(s))
+	} else {
+		panic("unreachable")
+	}
+}
+
+// escape characters
+func escapeGitHub(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	return s
+}
+
+// SetLoggerFlag will update the logger's output flags.
 func SetLoggerFlag(f int) {
 	logger.SetFlags(f)
 }

--- a/util/log.go
+++ b/util/log.go
@@ -8,53 +8,137 @@ import (
 	"strings"
 )
 
-var (
-	flags  = log.LstdFlags | log.LUTC
-	logger = log.New(os.Stderr, "", flags)
-)
+// LogFunc represents a function that takes a context,
+// format string and number of interface{} and logs accordingly.
+type LogFunc func(context.Context, string, ...interface{})
 
-// Printf uses the logger to log a formatted string.
-func Printf(ctx context.Context, format string, v ...interface{}) {
-	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
-		logger.Printf(prefix+": "+format, v...)
-	} else {
-		logger.Printf(format, v...)
+// GetStandardLogger returns a logger that is used for debugging.
+// It logs to STDERR, has no prefix, and logs the date and time in UTC.
+func GetStandardLogger() *log.Logger {
+	return log.New(os.Stderr, "", log.LstdFlags|log.LUTC)
+}
+
+// GetCheckerLogger returns a logger designed for the CI checker.
+// It logs to STDOUT, has no prefix, and does not log any metadata.
+func GetCheckerLogger() *log.Logger {
+	return log.New(os.Stdout, "", 0)
+}
+
+// GetStandardEntries gets a slice of []ContextEntry given
+// a prefix and *log.Logger. All LogFuncs will default to StandardDebugf
+// since they are not included.
+func GetStandardEntries(prefix string, logger *log.Logger) []ContextEntry {
+	return []ContextEntry{
+		{
+			Key:   LoggerPrefix,
+			Value: prefix,
+		},
+		{
+			Key:   Logger,
+			Value: logger,
+		},
 	}
 }
 
-// Debugf calls Printf if the program is in DEBUG mode.
-func Debugf(ctx context.Context, format string, v ...interface{}) {
+// GetCheckerEntries gets a slice of []ContextEntry given
+// a prefix and *log.Logger. The Debug LogFunc will default to
+// StandardDebugf since it is not included.
+func GetCheckerEntries(prefix string, logger *log.Logger) []ContextEntry {
+	return []ContextEntry{
+		{
+			Key:   LoggerPrefix,
+			Value: prefix,
+		},
+		{
+			Key:   Logger,
+			Value: logger,
+		},
+		{
+			Key:   Warn,
+			Value: LogFunc(CheckerWarnf),
+		},
+		{
+			Key:   Err,
+			Value: LogFunc(CheckerErrf),
+		},
+	}
+}
+
+// Printf is a LogFunc that uses a logger to log a formatted string.
+func Printf(ctx context.Context, format string, v ...interface{}) {
+	if logger, ok := ctx.Value(Logger).(*log.Logger); ok && logger != nil {
+		if prefix, ok := ctx.Value(LoggerPrefix).(string); ok {
+			logger.Printf(prefix+": "+format, v...)
+		} else {
+			logger.Printf(format, v...)
+		}
+	} else {
+		panic("logger does not exist")
+	}
+}
+
+// StandardDebugf is a LogFunc that calls Printf if the program is in DEBUG mode.
+func StandardDebugf(ctx context.Context, format string, v ...interface{}) {
 	if IsDebug() {
 		Printf(ctx, format, v...)
 	}
 }
 
-// Warnf is used to output a warning, either to STDOUT in logger format for the CI checker
-// or STDERR for debugging.
-func Warnf(ctx context.Context, runFromChecker bool, format string, v ...interface{}) {
-	if runFromChecker {
-		CheckerWarn(ctx, fmt.Sprintf(format, v...))
+// Generic function used to call a LogFunc stored in the context using a ContextKey key,
+// calling a default LogFunc if the key is not set.
+func logf(ctx context.Context, key ContextKey, defaultLogf LogFunc, format string, v ...interface{}) {
+	if f, ok := ctx.Value(key).(LogFunc); ok && f != nil {
+		f(ctx, format, v...)
 	} else {
-		Debugf(ctx, format, v...)
+		defaultLogf(ctx, format, v...)
 	}
 }
 
-// CheckerErr outputs an error to STDOUT for the CI checker.
-func CheckerErr(ctx context.Context, s string) {
-	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
-		fmt.Printf("::error file=%s,line=1,col=1::%s\n", prefix, escapeGitHub(s))
-	} else {
-		panic("unreachable")
+// Debugf is a LogFunc that attempts to call the Debug LogFunc in the context, defaulting
+// to StandardDebugf if unset.
+func Debugf(ctx context.Context, format string, v ...interface{}) {
+	logf(ctx, Debug, StandardDebugf, format, v...)
+}
+
+// Warnf is a LogFunc that attempts to call the Warn LogFunc in the context, defaulting
+// to StandardDebugf if unset.
+func Warnf(ctx context.Context, format string, v ...interface{}) {
+	logf(ctx, Warn, StandardDebugf, format, v...)
+}
+
+// Errf is a LogFunc that attempts to call the Err LogFunc in the context, defaulting
+// to StandardDebugf if unset.
+func Errf(ctx context.Context, format string, v ...interface{}) {
+	logf(ctx, Err, StandardDebugf, format, v...)
+}
+
+// Used to determine the type of the checker's log output.
+type checkerLogType string
+
+const (
+	checkerErr  checkerLogType = "error"
+	checkerWarn checkerLogType = "warning"
+)
+
+// Generic function used to output a checkerLogType to STDOUT for the CI checker.
+func checkerLogf(ctx context.Context, logType checkerLogType, format string, v ...interface{}) {
+	if logger, ok := ctx.Value(Logger).(*log.Logger); ok && logger != nil {
+		if prefix, ok := ctx.Value(LoggerPrefix).(string); ok {
+			logger.Printf("::%s file=%s,line=1,col=1::%s\n", logType, prefix, escapeGitHub(fmt.Sprintf(format, v...)))
+		} else {
+			panic("logger prefix does not exist")
+		}
 	}
 }
 
-// CheckerWarn outputs a warning to STDOUT for the CI checker.
-func CheckerWarn(ctx context.Context, s string) {
-	if prefix, ok := ctx.Value("loggerPrefix").(string); ok {
-		fmt.Printf("::warning file=%s,line=1,col=1::%s\n", prefix, escapeGitHub(s))
-	} else {
-		panic("unreachable")
-	}
+// CheckerErrf outputs an error to STDOUT for the CI checker.
+func CheckerErrf(ctx context.Context, format string, v ...interface{}) {
+	checkerLogf(ctx, checkerErr, format, v...)
+}
+
+// CheckerWarnf outputs a warning to STDOUT for the CI checker.
+func CheckerWarnf(ctx context.Context, format string, v ...interface{}) {
+	checkerLogf(ctx, checkerWarn, format, v...)
 }
 
 // escape characters
@@ -63,9 +147,4 @@ func escapeGitHub(s string) string {
 	s = strings.ReplaceAll(s, "\n", "%0A")
 	s = strings.ReplaceAll(s, "\r", "%0D")
 	return s
-}
-
-// SetLoggerFlag will update the logger's output flags.
-func SetLoggerFlag(f int) {
-	logger.SetFlags(f)
 }


### PR DESCRIPTION
Response to [last PR](https://github.com/cdnjs/tools/pull/28):

> We can switch the util.Debugf calls util.Warnf for warnings, when run from the autoupdater it will just log in stderr and run from the checker it will format the warning in CI format.

This function has been added as well as `util.CheckerErr` and `util.CheckerWarn` to avoid code duplication.