### PR TITLE
Minor Fixes / Refactoring show-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ We are going to create the home at `/tmp/cdnjs` and do the following in the dire
 In glob run `npm install`.
 
 Finally pass the `BOT_BASE_PATH` to the tool, for example: `BOT_BASE_PATH=/tmp/cdnjs bin/autoupdate -no-update`.
+

--- a/README.md
+++ b/README.md
@@ -26,4 +26,3 @@ We are going to create the home at `/tmp/cdnjs` and do the following in the dire
 In glob run `npm install`.
 
 Finally pass the `BOT_BASE_PATH` to the tool, for example: `BOT_BASE_PATH=/tmp/cdnjs bin/autoupdate -no-update`.
-

--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -56,7 +56,7 @@ func updateGit(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 
 		versionDiff := gitVersionDiff(gitVersions, existingVersionSet)
 
-		newGitVersions := make([]git.GitVersion, 0)
+		newGitVersions := make([]git.Version, 0)
 
 		for i := len(versionDiff) - 1; i >= 0; i-- {
 			gitVersion, err := semver.Make(versionDiff[i].Version)
@@ -94,7 +94,7 @@ func updateGit(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 	return newVersionsToCommit
 }
 
-func doUpdateGit(ctx context.Context, pckg *packages.Package, gitpath string, versions []git.GitVersion) []newVersionToCommit {
+func doUpdateGit(ctx context.Context, pckg *packages.Package, gitpath string, versions []git.Version) []newVersionToCommit {
 	newVersionsToCommit := make([]newVersionToCommit, 0)
 
 	if len(versions) == 0 {
@@ -147,8 +147,8 @@ func doUpdateGit(ctx context.Context, pckg *packages.Package, gitpath string, ve
 	return newVersionsToCommit
 }
 
-func gitVersionDiff(a []git.GitVersion, b []string) []git.GitVersion {
-	diff := make([]git.GitVersion, 0)
+func gitVersionDiff(a []git.Version, b []string) []git.Version {
+	diff := make([]git.Version, 0)
 	m := make(map[string]bool)
 
 	for _, item := range b {

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -49,7 +49,7 @@ func main() {
 	flag.Parse()
 
 	if util.IsDebug() {
-		fmt.Println("Running in debug mode", noUpdate)
+		fmt.Printf("Running in debug mode (no-update=%t)\n", noUpdate)
 	}
 
 	util.UpdateGitRepo(defaultCtx, CDNJS_PATH)

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -27,7 +27,7 @@ func updateNpm(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 		versionDiff := npmVersionDiff(npmVersions, existingVersionSet)
 		sort.Sort(npm.ByNpmVersion(versionDiff))
 
-		newNpmVersions := make([]npm.NpmVersion, 0)
+		newNpmVersions := make([]npm.Version, 0)
 		skippedVersions := make([]string, 0)
 
 		for i := len(versionDiff) - 1; i >= 0; i-- {
@@ -75,7 +75,7 @@ func updateNpm(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 	return newVersionsToCommit
 }
 
-func doUpdateNpm(ctx context.Context, pckg *packages.Package, versions []npm.NpmVersion) []newVersionToCommit {
+func doUpdateNpm(ctx context.Context, pckg *packages.Package, versions []npm.Version) []newVersionToCommit {
 	newVersionsToCommit := make([]newVersionToCommit, 0)
 
 	if len(versions) == 0 {
@@ -131,8 +131,8 @@ func doUpdateNpm(ctx context.Context, pckg *packages.Package, versions []npm.Npm
 	return newVersionsToCommit
 }
 
-func npmVersionDiff(a []npm.NpmVersion, b []string) []npm.NpmVersion {
-	diff := make([]npm.NpmVersion, 0)
+func npmVersionDiff(a []npm.Version, b []string) []npm.Version {
+	diff := make([]npm.Version, 0)
 	m := make(map[string]bool)
 
 	for _, item := range b {

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -188,7 +188,7 @@ func printLastVersions(ctx context.Context, p *packages.Package, dir string, ver
 		downloadDir := version.Download(ctx, p, dir)
 		defer version.Clean(downloadDir)
 
-		filesToCopy := p.NpmFilesFrom(dir)
+		filesToCopy := p.NpmFilesFrom(downloadDir)
 
 		fmt.Printf("- %s: %d file(s) matched", version.Get(), len(filesToCopy))
 		if len(filesToCopy) > 0 {

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -107,7 +107,6 @@ func showFiles(pckgPath string) {
 				err(ctx, fmt.Sprintf("could not clone repo: %s: %s\n", cloneerr, out))
 				return
 			}
-			downloadDir = packageGitDir
 
 			// get git versions and sort
 			gitVersions := git.GetVersions(ctx, pckg, packageGitDir)
@@ -118,6 +117,8 @@ func showFiles(pckgPath string) {
 				versions = append(versions, &v)
 			}
 
+			// set download dir
+			downloadDir = packageGitDir
 		}
 	default:
 		{
@@ -175,7 +176,7 @@ func printCurrentVersion(ctx context.Context, p *packages.Package, dir string, v
 // Each previous version will be downloaded and cleaned up if necessary.
 // For example, a temporary directory may be downloaded and then removed later.
 func printLastVersions(ctx context.Context, p *packages.Package, dir string, versions []version) {
-	fmt.Printf("\n%d last versions:\n", len(versions))
+	fmt.Printf("\n%d last version(s):\n", len(versions))
 	for _, version := range versions {
 		version.Download(ctx, p, dir)
 		defer version.Clean()

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -157,6 +157,7 @@ func showFiles(pckgPath string) {
 // Prints the files of a package version, outputting debug
 // messages if no valid files are present.
 func printCurrentVersion(ctx context.Context, p *packages.Package, dir string, v version) {
+	fmt.Printf("\ncurrent version: %s\n", v.Get())
 	filesToCopy := p.NpmFilesFrom(dir)
 
 	if len(filesToCopy) == 0 {
@@ -179,7 +180,7 @@ func printCurrentVersion(ctx context.Context, p *packages.Package, dir string, v
 		return
 	}
 
-	fmt.Printf("```\n")
+	fmt.Printf("\n```\n")
 	for _, file := range filesToCopy {
 		fmt.Printf("%s\n", file.To)
 	}

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -56,7 +56,7 @@ func main() {
 // Represents a version of a package,
 // which could be a git version, npm version, etc.
 type version interface {
-	Get() string                    // Get a version
+	Get() string                    // Get the version as a string
 	Download(...interface{}) string // Download a version, returning the download dir
 	Clean(string)                   // Clean a download dir
 }

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -81,7 +81,7 @@ func showFiles(pckgPath string) {
 	// autoupdate exists, download latest versions based on source
 	src := pckg.Autoupdate.Source
 	var versions []version
-	var downloadDir string
+	var downloadDir, noVersionsErr string
 	switch src {
 	case "npm":
 		{
@@ -96,6 +96,9 @@ func showFiles(pckgPath string) {
 
 			// download into temp dir
 			downloadDir = npm.DownloadTar(ctx, npmVersions[0].Tarball)
+
+			// set err string if no versions
+			noVersionsErr = "no version found on npm"
 		}
 	case "git":
 		{
@@ -119,6 +122,9 @@ func showFiles(pckgPath string) {
 
 			// set download dir
 			downloadDir = packageGitDir
+
+			// set err string if no versions
+			noVersionsErr = "no tagged version found in git"
 		}
 	default:
 		{
@@ -132,7 +138,7 @@ func showFiles(pckgPath string) {
 
 	// enforce at least one version
 	if len(versions) == 0 {
-		err(ctx, fmt.Sprintf("no version found on %s", src))
+		err(ctx, noVersionsErr)
 		return
 	}
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -122,7 +122,8 @@ func showFiles(pckgPath string) {
 		}
 	default:
 		{
-			panic(fmt.Sprintf("unknown autoupdate source: %s", src))
+			err(ctx, fmt.Sprintf("unknown autoupdate source: %s", src))
+			return
 		}
 	}
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -56,9 +56,9 @@ func main() {
 // Represents a version of a package,
 // which could be a git version, npm version, etc.
 type version interface {
-	Get() string
-	Download(...interface{})
-	Clean()
+	Get() string                    // Get a version
+	Download(...interface{}) string // Download a version, returning the download dir
+	Clean(string)                   // Clean a download dir
 }
 
 func showFiles(pckgPath string) {
@@ -91,7 +91,7 @@ func showFiles(pckgPath string) {
 
 			// cast to interface
 			for _, v := range npmVersions {
-				versions = append(versions, &v)
+				versions = append(versions, v)
 			}
 
 			// download into temp dir
@@ -114,7 +114,7 @@ func showFiles(pckgPath string) {
 
 			// cast to interface
 			for _, v := range gitVersions {
-				versions = append(versions, &v)
+				versions = append(versions, v)
 			}
 
 			// set download dir
@@ -178,8 +178,8 @@ func printCurrentVersion(ctx context.Context, p *packages.Package, dir string, v
 func printLastVersions(ctx context.Context, p *packages.Package, dir string, versions []version) {
 	fmt.Printf("\n%d last version(s):\n", len(versions))
 	for _, version := range versions {
-		version.Download(ctx, p, dir)
-		defer version.Clean()
+		downloadDir := version.Download(ctx, p, dir)
+		defer version.Clean(downloadDir)
 
 		filesToCopy := p.NpmFilesFrom(dir)
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -156,8 +156,15 @@ func printCurrentVersion(ctx context.Context, p *packages.Package, dir string, v
 		errormsg := ""
 		errormsg += fmt.Sprintf("No files will be published for version %s.\n", v.Get())
 
+		// determine if a pattern has been seen before
+		seen := make(map[string]bool)
+
 		for _, filemap := range p.NpmFileMap {
 			for _, pattern := range filemap.Files {
+				if _, ok := seen[pattern]; ok {
+					continue // skip duplicate pattern
+				}
+				seen[pattern] = true
 				errormsg += fmt.Sprintf("[Click here to debug your glob pattern `%s`](%s).\n", pattern, makeGlobDebugLink(pattern, dir))
 			}
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -15,18 +15,19 @@ type Version struct {
 }
 
 // Get gets the version of a particular Version.
-func (g *Version) Get() string {
+func (g Version) Get() string {
 	return g.Version
 }
 
 // Download will git check out a particular version.
-func (g *Version) Download(args ...interface{}) {
+func (g Version) Download(args ...interface{}) string {
 	ctx, p, dir := args[0].(context.Context), args[1].(*packages.Package), args[2].(string)
 	packages.GitForceCheckout(ctx, p, dir, g.Tag)
+	return dir // download dir is the same as original dir
 }
 
 // Clean is used to satisfy the checker's version interface.
-func (g *Version) Clean() {
+func (g Version) Clean(_ string) {
 }
 
 // GetVersions gets all of the versions associated with a git repo.

--- a/git/git.go
+++ b/git/git.go
@@ -8,33 +8,35 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
-type GitVersion struct {
+// Version represents a version of a git repo.
+type Version struct {
 	Tag     string
 	Version string
 }
 
-// Get gets the version of a particular GitVersion.
-func (g *GitVersion) Get() string {
+// Get gets the version of a particular Version.
+func (g *Version) Get() string {
 	return g.Version
 }
 
 // Download will git check out a particular version.
-func (g *GitVersion) Download(args ...interface{}) {
+func (g *Version) Download(args ...interface{}) {
 	ctx, p, dir := args[0].(context.Context), args[1].(*packages.Package), args[2].(string)
 	packages.GitForceCheckout(ctx, p, dir, g.Tag)
 }
 
 // Clean is used to satisfy the checker's version interface.
-func (g *GitVersion) Clean() {
+func (g *Version) Clean() {
 }
 
-func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache string) []GitVersion {
+// GetVersions gets all of the versions associated with a git repo.
+func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache string) []Version {
 	gitTags := packages.GitTags(ctx, pckg, packageGitcache)
 	util.Debugf(ctx, "found tags in git: %s\n", gitTags)
 
-	gitVersions := make([]GitVersion, 0)
+	gitVersions := make([]Version, 0)
 	for _, tag := range gitTags {
-		gitVersions = append(gitVersions, GitVersion{
+		gitVersions = append(gitVersions, Version{
 			Tag:     tag,
 			Version: strings.TrimPrefix(tag, "v"),
 		})

--- a/git/git.go
+++ b/git/git.go
@@ -13,6 +13,21 @@ type GitVersion struct {
 	Version string
 }
 
+// Get gets the version of a particular GitVersion.
+func (g *GitVersion) Get() string {
+	return g.Version
+}
+
+// Download will git check out a particular version.
+func (g *GitVersion) Download(args ...interface{}) {
+	ctx, p, dir := args[0].(context.Context), args[1].(*packages.Package), args[2].(string)
+	packages.GitForceCheckout(ctx, p, dir, g.Tag)
+}
+
+// Clean is used to satisfy the checker's version interface.
+func (g *GitVersion) Clean() {
+}
+
 func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache string) []GitVersion {
 	gitTags := packages.GitTags(ctx, pckg, packageGitcache)
 	util.Debugf(ctx, "found tags in git: %s\n", gitTags)

--- a/git/sort.go
+++ b/git/sort.go
@@ -4,7 +4,8 @@ import (
 	"github.com/blang/semver"
 )
 
-type ByGitVersion []GitVersion
+// ByGitVersion implements sort.Interface for []Version
+type ByGitVersion []Version
 
 func (a ByGitVersion) Len() int      { return len(a) }
 func (a ByGitVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }

--- a/npm/registry.go
+++ b/npm/registry.go
@@ -1,9 +1,11 @@
 package npm
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/cdnjs/tools/util"
 )
@@ -13,8 +15,26 @@ type NpmRegistryPackage struct {
 }
 
 type NpmVersion struct {
+	tarballDir string
+
 	Version string
 	Tarball string
+}
+
+// Get gets the version of a particular NpmVersion.
+func (n *NpmVersion) Get() string {
+	return n.Version
+}
+
+// Download will download a particular npm version.
+func (n *NpmVersion) Download(args ...interface{}) {
+	ctx := args[0].(context.Context)
+	n.tarballDir = DownloadTar(ctx, n.Tarball)
+}
+
+// Clean is used to satisfy the checker's version interface.
+func (n *NpmVersion) Clean() {
+	os.RemoveAll(n.tarballDir) // clean up temp tarball dir
 }
 
 type MonthlyDownload struct {

--- a/npm/registry.go
+++ b/npm/registry.go
@@ -18,8 +18,6 @@ type RegistryPackage struct {
 
 // Version represents a version of an npm package.
 type Version struct {
-	tarballDir string
-
 	Version string
 	Tarball string
 }

--- a/npm/registry.go
+++ b/npm/registry.go
@@ -25,19 +25,19 @@ type Version struct {
 }
 
 // Get gets the version of a particular Version.
-func (n *Version) Get() string {
+func (n Version) Get() string {
 	return n.Version
 }
 
 // Download will download a particular npm version.
-func (n *Version) Download(args ...interface{}) {
+func (n Version) Download(args ...interface{}) string {
 	ctx := args[0].(context.Context)
-	n.tarballDir = DownloadTar(ctx, n.Tarball)
+	return DownloadTar(ctx, n.Tarball) // return download dir
 }
 
-// Clean is used to satisfy the checker's version interface.
-func (n *Version) Clean() {
-	os.RemoveAll(n.tarballDir) // clean up temp tarball dir
+// Clean is used to clean up a download directory.
+func (n Version) Clean(downloadDir string) {
+	os.RemoveAll(downloadDir) // clean up temp tarball dir
 }
 
 // MonthlyDownload holds the number of monthly downloads

--- a/npm/registry.go
+++ b/npm/registry.go
@@ -10,33 +10,38 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
-type NpmRegistryPackage struct {
+// RegistryPackage contains metadata about the versions for
+// a particular npm package.
+type RegistryPackage struct {
 	Versions map[string]interface{} `json:"versions"`
 }
 
-type NpmVersion struct {
+// Version represents a version of an npm package.
+type Version struct {
 	tarballDir string
 
 	Version string
 	Tarball string
 }
 
-// Get gets the version of a particular NpmVersion.
-func (n *NpmVersion) Get() string {
+// Get gets the version of a particular Version.
+func (n *Version) Get() string {
 	return n.Version
 }
 
 // Download will download a particular npm version.
-func (n *NpmVersion) Download(args ...interface{}) {
+func (n *Version) Download(args ...interface{}) {
 	ctx := args[0].(context.Context)
 	n.tarballDir = DownloadTar(ctx, n.Tarball)
 }
 
 // Clean is used to satisfy the checker's version interface.
-func (n *NpmVersion) Clean() {
+func (n *Version) Clean() {
 	os.RemoveAll(n.tarballDir) // clean up temp tarball dir
 }
 
+// MonthlyDownload holds the number of monthly downloads
+// for an npm package.
 type MonthlyDownload struct {
 	Downloads uint `json:"downloads"`
 }
@@ -49,12 +54,15 @@ func getProtocol() string {
 	}
 }
 
+// Exists determines if an npm package exists.
 func Exists(name string) bool {
 	resp, err := http.Get(getProtocol() + "://registry.npmjs.org/" + name)
 	util.Check(err)
 	return resp.StatusCode == http.StatusOK
 }
 
+// GetMonthlyDownload uses the npm API to get the MonthlyDownload
+// for a particular npm package.
 func GetMonthlyDownload(name string) MonthlyDownload {
 	resp, err := http.Get(getProtocol() + "://api.npmjs.org/downloads/point/last-month/" + name)
 	util.Check(err)
@@ -68,7 +76,8 @@ func GetMonthlyDownload(name string) MonthlyDownload {
 	return counts
 }
 
-func GetVersions(name string) []NpmVersion {
+// GetVersions gets all of the versions associated with an npm package.
+func GetVersions(name string) []Version {
 	resp, err := http.Get(getProtocol() + "://registry.npmjs.org/" + name)
 	util.Check(err)
 
@@ -76,16 +85,16 @@ func GetVersions(name string) []NpmVersion {
 	body, err := ioutil.ReadAll(resp.Body)
 	util.Check(err)
 
-	var npmRegistryPackage NpmRegistryPackage
+	var npmRegistryPackage RegistryPackage
 	util.Check(json.Unmarshal(body, &npmRegistryPackage))
 
-	versions := make([]NpmVersion, 0)
+	versions := make([]Version, 0)
 
 	for k, v := range npmRegistryPackage.Versions {
 		if v, ok := v.(map[string]interface{}); ok {
 			dist := v["dist"].(map[string]interface{})
 
-			versions = append(versions, NpmVersion{
+			versions = append(versions, Version{
 				Version: k,
 				Tarball: dist["tarball"].(string),
 			})

--- a/npm/registry.go
+++ b/npm/registry.go
@@ -3,23 +3,26 @@ package npm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/cdnjs/tools/util"
 )
 
-// RegistryPackage contains metadata about the versions for
-// a particular npm package.
-type RegistryPackage struct {
-	Versions map[string]interface{} `json:"versions"`
+// Registry contains metadata about a particular npm package.
+type Registry struct {
+	Versions   map[string]interface{} `json:"versions"` // Versions contains metadata about each npm version.
+	TimeStamps map[string]string      `json:"time"`     // TimeStamps contains times for each versions as well as the created/modified time.
 }
 
 // Version represents a version of an npm package.
 type Version struct {
-	Version string
-	Tarball string
+	Version   string
+	Tarball   string
+	TimeStamp time.Time
 }
 
 // Get gets the version of a particular Version.
@@ -83,19 +86,28 @@ func GetVersions(name string) []Version {
 	body, err := ioutil.ReadAll(resp.Body)
 	util.Check(err)
 
-	var npmRegistryPackage RegistryPackage
-	util.Check(json.Unmarshal(body, &npmRegistryPackage))
+	var r Registry
+	util.Check(json.Unmarshal(body, &r))
 
 	versions := make([]Version, 0)
-
-	for k, v := range npmRegistryPackage.Versions {
+	for k, v := range r.Versions {
 		if v, ok := v.(map[string]interface{}); ok {
-			dist := v["dist"].(map[string]interface{})
+			if timeStr, ok := r.TimeStamps[k]; ok {
 
-			versions = append(versions, Version{
-				Version: k,
-				Tarball: dist["tarball"].(string),
-			})
+				// parse time.Time from time stamp
+				timeStamp, err := time.Parse(time.RFC3339, timeStr)
+				util.Check(err)
+
+				dist := v["dist"].(map[string]interface{})
+
+				versions = append(versions, Version{
+					Version:   k,
+					Tarball:   dist["tarball"].(string),
+					TimeStamp: timeStamp,
+				})
+				continue
+			}
+			panic(fmt.Sprintf("no time stamp for npm version %s", k))
 		}
 	}
 

--- a/npm/sort.go
+++ b/npm/sort.go
@@ -4,8 +4,8 @@ import (
 	"github.com/blang/semver"
 )
 
-// ByNpmVersion implements sort.Interface for []NpmVersion
-type ByNpmVersion []NpmVersion
+// ByNpmVersion implements sort.Interface for []Version
+type ByNpmVersion []Version
 
 func (a ByNpmVersion) Len() int      { return len(a) }
 func (a ByNpmVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }


### PR DESCRIPTION
This PR was supposed to be only minor fixes, but I noticed the checker's `show-files` function could be broken into reusable methods to avoid code duplication and confusing `goto` statements.

Minor fixes:
- output `no-update` flag in autoupdate
- show-files does not display the first version twice
- glob patterns are ignored if repeated

Refactoring show-files:
- use of a `version` interface to avoid code duplication (implemented by `git.GitVersion` and `npm.NpmVersion`)
- `git.GitVersion` refactored to `git.Version` (go-lint)
- `npm.NpmVersion` refactored to `npm.Version` (go-lint)
- increased documentation

I tested with hi-sven npm/git and it looks good from what I can see!