### PR TITLE
Enforce Version to be Nonexistent for CI Checker

### DIFF
--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -237,8 +237,8 @@ func lintPackage(pckgPath string) {
 		err(ctx, shouldNotBeEmpty(".name"))
 	}
 
-	if pckg.Version != "" {
-		err(ctx, shouldBeEmpty(".version"))
+	if pckg.Version != nil {
+		err(ctx, shouldNotExist(".version"))
 	}
 
 	// if pckg.NpmName != nil && *pckg.NpmName == "" {
@@ -292,10 +292,12 @@ func warn(ctx context.Context, s string) {
 	util.Warnf(ctx, s)
 }
 
-func shouldBeEmpty(name string) string {
-	return fmt.Sprintf("%s should be empty", name)
-}
-
+// a tag should not be empty
 func shouldNotBeEmpty(name string) string {
 	return fmt.Sprintf("%s should be specified", name)
+}
+
+// a tag should not exist
+func shouldNotExist(name string) string {
+	return fmt.Sprintf("%s should not exist", name)
 }

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -292,12 +292,10 @@ func warn(ctx context.Context, s string) {
 	util.Warnf(ctx, s)
 }
 
-// a tag should not be empty
 func shouldNotBeEmpty(name string) string {
 	return fmt.Sprintf("%s should be specified", name)
 }
 
-// a tag should not exist
 func shouldNotExist(name string) string {
 	return fmt.Sprintf("%s should not exist", name)
 }

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -54,7 +54,7 @@ func generatePackageWorker(jobs <-chan string, results chan<- *outputPackage) {
 			return
 		}
 
-		if p.Version == "" {
+		if p.Version == nil || *p.Version == "" {
 			util.Printf(ctx, "version is invalid\n")
 			results <- nil
 			return
@@ -171,7 +171,7 @@ func generatePackage(ctx context.Context, p *packages.Package) *outputPackage {
 	out := outputPackage{}
 
 	out.Name = p.Name
-	out.Version = p.Version
+	out.Version = *p.Version
 	out.Description = p.Description
 	out.Filename = p.Filename
 	out.Repository = map[string]string{

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -50,7 +50,7 @@ type Package struct {
 	Title       string
 	Name        string
 	Description string
-	Version     string
+	Version     *string
 	Author      Author
 	Homepage    string
 	Keywords    []string

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -37,7 +37,8 @@ func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 		case "description":
 			p.Description = value.(string)
 		case "version":
-			p.Version = value.(string)
+			s := value.(string)
+			p.Version = &s
 		case "author":
 			{
 				if str, ok := value.(string); ok {


### PR DESCRIPTION
This is to fix [packages issue #276](https://github.com/cdnjs/packages/issues/276).