### PR TITLE
update codebase for go-lint compliance

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: tools
-on: push
+on: [push, pull_request]
 
 jobs:
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,3 +71,14 @@ jobs:
 
       - name: run tests
         run: make test
+
+  lint:
+    name: golint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.26

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,8 @@ clean:
 .PHONY: test
 test: clean checker
 	go test -v ./test/...
+
+.PHONY: lint
+lint:
+	go get -u golang.org/x/lint/golint
+	$(GOPATH)/bin/golint ./...

--- a/algolia/client.go
+++ b/algolia/client.go
@@ -1,3 +1,6 @@
+// Package algolia contains functions used to interact with the
+// Algolia Seach API to update the search index used for autocomplete on
+// the cdnjs website.
 package algolia
 
 import (
@@ -8,14 +11,17 @@ import (
 )
 
 var (
-	tmpIndex  = "libraries.tmp"
-	prodIndex = "libraries"
+	tmpIndex  = "libraries.tmp" // temp Algolia index
+	prodIndex = "libraries"     // production Algolia index
 )
 
+// GetClient instantiates a new client to interact with the Algolia Search API
+// using an Application ID and API key.
 func GetClient() *search.Client {
 	return search.NewClient("2QWLVLXZB6", util.GetEnv("ALGOLIA_WRITE_API_KEY"))
 }
 
+// GetTmpIndex instantiates and configures a new temporary Algolia Search index.
 func GetTmpIndex(client *search.Client) *search.Index {
 	index := client.InitIndex(tmpIndex)
 	_, err := index.SetSettings(search.Settings{
@@ -44,6 +50,7 @@ func GetTmpIndex(client *search.Client) *search.Index {
 	return index
 }
 
+// PromoteIndex promotes the temporary Algolia Search index to production.
 func PromoteIndex(client *search.Client) {
 	_, err := client.MoveIndex(tmpIndex, prodIndex)
 	util.Check(err)

--- a/algolia/client.go
+++ b/algolia/client.go
@@ -11,6 +11,11 @@ import (
 )
 
 var (
+	// The Algolia temporary index was used by the previous bot
+	// and I just copied it over because I didn't know how it worked.
+	// I don't see the value of building a temporary index and at the
+	// end renaming it to the production index. I would rather maintain
+	// a single index and only update entries when the bot pushed a new update.
 	tmpIndex  = "libraries.tmp" // temp Algolia index
 	prodIndex = "libraries"     // production Algolia index
 )

--- a/cloudstorage/object.go
+++ b/cloudstorage/object.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// GetAssetsBucket gets the GCP BucketHandle for cdnjs assets.
 func GetAssetsBucket(ctx context.Context) (*storage.BucketHandle, error) {
 	client, err := gcp.GetStorageClient(ctx)
 	util.Check(err)
@@ -15,6 +16,7 @@ func GetAssetsBucket(ctx context.Context) (*storage.BucketHandle, error) {
 	return bkt, nil
 }
 
+// GetRobotcdnjsBucket gets the GCP BucketHandle for robotcdnjs.
 func GetRobotcdnjsBucket(ctx context.Context) (*storage.BucketHandle, error) {
 	client, err := gcp.GetStorageClient(ctx)
 	util.Check(err)

--- a/cloudstorage/object.go
+++ b/cloudstorage/object.go
@@ -15,11 +15,3 @@ func GetAssetsBucket(ctx context.Context) (*storage.BucketHandle, error) {
 	bkt := client.Bucket("cdnjs-assets")
 	return bkt, nil
 }
-
-// GetRobotcdnjsBucket gets the GCP BucketHandle for robotcdnjs.
-func GetRobotcdnjsBucket(ctx context.Context) (*storage.BucketHandle, error) {
-	client, err := gcp.GetStorageClient(ctx)
-	util.Check(err)
-	bkt := client.Bucket("robotcdnjs")
-	return bkt, nil
-}

--- a/cmd/algolia/main.go
+++ b/cmd/algolia/main.go
@@ -216,7 +216,7 @@ func getGitHubMeta(repo *packages.Repository) (*GitHubMeta, error) {
 }
 
 func getSRI(p *Package) (string, error) {
-	jsonFile := path.Join(util.SRI_PATH, p.Name, p.Version+".json")
+	jsonFile := path.Join(util.SRIPath, p.Name, p.Version+".json")
 
 	var j map[string]interface{}
 

--- a/cmd/algolia/main.go
+++ b/cmd/algolia/main.go
@@ -160,7 +160,7 @@ func parseRepository(p *Package) (*packages.Repository, error) {
 		{
 			return &packages.Repository{
 				Repotype: "",
-				Url:      v,
+				URL:      v,
 			}, nil
 		}
 	case map[string]interface{}:
@@ -168,7 +168,7 @@ func parseRepository(p *Package) (*packages.Repository, error) {
 			if v["type"] != nil && v["url"] != nil {
 				return &packages.Repository{
 					Repotype: v["type"].(string),
-					Url:      v["url"].(string),
+					URL:      v["url"].(string),
 				}, nil
 			}
 			return nil, nil
@@ -195,9 +195,9 @@ func getGitHubMeta(repo *packages.Repository) (*GitHubMeta, error) {
 		return nil, fmt.Errorf("unsupported repo type `%s`", repo.Repotype)
 	}
 
-	res := githubURL.FindAllStringSubmatch(repo.Url, -1)
+	res := githubURL.FindAllStringSubmatch(repo.URL, -1)
 	if len(res) == 0 {
-		return nil, fmt.Errorf("could not parse repo URL `%s`", repo.Url)
+		return nil, fmt.Errorf("could not parse repo URL `%s`", repo.URL)
 	}
 
 	client := github.GetClient()

--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -78,8 +78,8 @@ func updateGit(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 			// too many outdated versions.
 			sort.Sort(sort.Reverse(git.ByTimeStamp(gitVersions)))
 
-			if len(gitVersions) > util.IMPORT_ALL_MAX_VERSIONS {
-				gitVersions = gitVersions[len(gitVersions)-util.IMPORT_ALL_MAX_VERSIONS:]
+			if len(gitVersions) > util.ImportAllMaxVersions {
+				gitVersions = gitVersions[len(gitVersions)-util.ImportAllMaxVersions:]
 			}
 
 			// Reverse the array to have the older versions first

--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -49,7 +49,7 @@ func updateGit(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 	lastExistingVersion := git.GetMostRecentExistingVersion(ctx, existingVersionSet, gitVersions)
 
 	if lastExistingVersion != nil {
-		util.Debugf(ctx, "last existing version: %s\n", lastExistingVersion)
+		util.Debugf(ctx, "last existing version: %s\n", lastExistingVersion.Version)
 
 		versionDiff := gitVersionDiff(gitVersions, existingVersionSet)
 

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -151,7 +151,7 @@ func compressNewVersion(ctx context.Context, version newVersionToCommit) {
 		files := filterByExt(files, compress.JpegExt)
 		for _, file := range files {
 			absfile := path.Join(version.versionPath, file)
-			compress.CompressJpeg(ctx, absfile)
+			compress.Jpeg(ctx, absfile)
 		}
 	}
 	// png
@@ -163,7 +163,7 @@ func compressNewVersion(ctx context.Context, version newVersionToCommit) {
 			files := filterByExt(files, compress.PngExt)
 			for _, file := range files {
 				absfile := path.Join(version.versionPath, file)
-				compress.CompressPng(ctx, absfile)
+				compress.Png(ctx, absfile)
 			}
 		}
 	}
@@ -172,15 +172,15 @@ func compressNewVersion(ctx context.Context, version newVersionToCommit) {
 		files := filterByExt(files, compress.JsExt)
 		for _, file := range files {
 			absfile := path.Join(version.versionPath, file)
-			compress.CompressJs(ctx, absfile)
+			compress.Js(ctx, absfile)
 		}
 	}
 	// css
 	{
-		files := filterByExt(files, compress.CssExt)
+		files := filterByExt(files, compress.CSSExt)
 		for _, file := range files {
 			absfile := path.Join(version.versionPath, file)
-			compress.CompressCss(ctx, absfile)
+			compress.CSS(ctx, absfile)
 		}
 	}
 }

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -48,8 +48,8 @@ func updateNpm(ctx context.Context, pckg *packages.Package) []newVersionToCommit
 			// too many outdated versions.
 			sort.Sort(sort.Reverse(npm.ByTimeStamp(npmVersions)))
 
-			if len(npmVersions) > util.IMPORT_ALL_MAX_VERSIONS {
-				npmVersions = npmVersions[len(npmVersions)-util.IMPORT_ALL_MAX_VERSIONS:]
+			if len(npmVersions) > util.ImportAllMaxVersions {
+				npmVersions = npmVersions[len(npmVersions)-util.ImportAllMaxVersions:]
 			}
 
 			npmVersionsStr := make([]string, len(npmVersions))

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -49,7 +49,7 @@ func main() {
 			}
 		}
 	default:
-		panic(fmt.Sprintf("unknown subcommand: '%s'", subcommand))
+		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))
 	}
 }
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -143,8 +143,8 @@ func showFiles(pckgPath string) {
 	}
 
 	// limit versions
-	if len(versions) > util.IMPORT_ALL_MAX_VERSIONS {
-		versions = versions[:util.IMPORT_ALL_MAX_VERSIONS]
+	if len(versions) > util.ImportAllMaxVersions {
+		versions = versions[:util.ImportAllMaxVersions]
 	}
 
 	// print info for first src version
@@ -260,8 +260,8 @@ func lintPackage(pckgPath string) {
 				}
 
 				// check if it has enough downloads
-				if md := npm.GetMonthlyDownload(pckg.Autoupdate.Target); md.Downloads < util.MIN_NPM_MONTHLY_DOWNLOADS {
-					err(ctx, fmt.Sprintf("package download per month on npm is under %d", util.MIN_NPM_MONTHLY_DOWNLOADS))
+				if md := npm.GetMonthlyDownload(pckg.Autoupdate.Target); md.Downloads < util.MinNPMMonthlyDownloads {
+					err(ctx, fmt.Sprintf("package download per month on npm is under %d", util.MinNPMMonthlyDownloads))
 				}
 			}
 		case "git":

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -260,8 +260,8 @@ func lintPackage(pckgPath string) {
 				}
 
 				// check if it has enough downloads
-				if md := npm.GetMonthlyDownload(pckg.Autoupdate.Target); md.Downloads < util.MinNPMMonthlyDownloads {
-					err(ctx, fmt.Sprintf("package download per month on npm is under %d", util.MinNPMMonthlyDownloads))
+				if md := npm.GetMonthlyDownload(pckg.Autoupdate.Target); md.Downloads < util.MinNpmMonthlyDownloads {
+					err(ctx, fmt.Sprintf("package download per month on npm is under %d", util.MinNpmMonthlyDownloads))
 				}
 			}
 		case "git":

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -288,9 +288,9 @@ func err(ctx context.Context, s string) {
 }
 
 // wrapper around outputting a checker warning
-func warn(ctx context.Context, s string) {
-	util.Warnf(ctx, s)
-}
+// func warn(ctx context.Context, s string) {
+// 	util.Warnf(ctx, s)
+// }
 
 func shouldNotBeEmpty(name string) string {
 	return fmt.Sprintf("%s should be specified", name)

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -61,14 +61,14 @@ func generatePackageWorker(jobs <-chan string, results chan<- *outputPackage) {
 		}
 
 		for _, version := range p.Versions() {
-			if !hasSri(p, version) {
+			if !hasSRI(p, version) {
 				util.Printf(ctx, "version %s needs SRI calculation\n", version)
 
-				sriFileMap := p.CalculateVersionSris(version)
+				sriFileMap := p.CalculateVersionSRIs(version)
 				bytes, jsonErr := json.Marshal(sriFileMap)
 				util.Check(jsonErr)
 
-				writeSriJSON(p, version, bytes)
+				writeSRIJSON(p, version, bytes)
 			}
 
 			// FIXME: reenable that once we don't run in debug mode anymore
@@ -220,14 +220,14 @@ func generatePackage(ctx context.Context, p *packages.Package) *outputPackage {
 	return &out
 }
 
-func hasSri(p *packages.Package, version string) bool {
-	sriPath := path.Join(util.SRI_PATH, p.Name, version+".json")
+func hasSRI(p *packages.Package, version string) bool {
+	sriPath := path.Join(util.SRIPath, p.Name, version+".json")
 	_, statErr := os.Stat(sriPath)
 	return !os.IsNotExist(statErr)
 }
 
-func getSriFileMap(p *packages.Package, version string) map[string]string {
-	sriPath := path.Join(util.SRI_PATH, p.Name, version+".json")
+func getSRIFileMap(p *packages.Package, version string) map[string]string {
+	sriPath := path.Join(util.SRIPath, p.Name, version+".json")
 	data, err := ioutil.ReadFile(sriPath)
 	util.Check(err)
 
@@ -237,8 +237,8 @@ func getSriFileMap(p *packages.Package, version string) map[string]string {
 	return fileMap
 }
 
-func writeSriJSON(p *packages.Package, version string, content []byte) {
-	sriDir := path.Join(util.SRI_PATH, p.Name)
+func writeSRIJSON(p *packages.Package, version string, content []byte) {
+	sriDir := path.Join(util.SRIPath, p.Name)
 	if _, err := os.Stat(sriDir); os.IsNotExist(err) {
 		util.Check(os.MkdirAll(sriDir, 0777))
 	}

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -70,15 +70,6 @@ func generatePackageWorker(jobs <-chan string, results chan<- *outputPackage) {
 
 				writeSRIJSON(p, version, bytes)
 			}
-
-			// FIXME: reenable that once we don't run in debug mode anymore
-			// // In debug mode ensure that we still generate the same SRI;
-			// // compare with the existing ones (slow).
-			// if util.IsDebug() && hasSri(p, version) {
-			// 	expectedSriFileMap := getSriFileMap(p, version)
-			// 	actualSriFileMap := p.CalculateVersionSris(version)
-			// 	compareMaps(ctx, expectedSriFileMap, actualSriFileMap)
-			// }
 		}
 
 		util.Printf(ctx, "OK\n")
@@ -226,17 +217,6 @@ func hasSRI(p *packages.Package, version string) bool {
 	return !os.IsNotExist(statErr)
 }
 
-func getSRIFileMap(p *packages.Package, version string) map[string]string {
-	sriPath := path.Join(util.SRIPath, p.Name, version+".json")
-	data, err := ioutil.ReadFile(sriPath)
-	util.Check(err)
-
-	var fileMap map[string]string
-	util.Check(json.Unmarshal(data, &fileMap))
-
-	return fileMap
-}
-
 func writeSRIJSON(p *packages.Package, version string, content []byte) {
 	sriDir := path.Join(util.SRIPath, p.Name)
 	if _, err := os.Stat(sriDir); os.IsNotExist(err) {
@@ -245,17 +225,4 @@ func writeSRIJSON(p *packages.Package, version string, content []byte) {
 
 	sriFilename := path.Join(sriDir, version+".json")
 	util.Check(ioutil.WriteFile(sriFilename, content, 0777))
-}
-
-func compareMaps(ctx context.Context, a, b map[string]string) {
-	for k := range a {
-		if _, bHas := b[k]; !bHas {
-			util.Printf(ctx, "Sri non existing for file %s\n", k)
-			continue
-		}
-		if a[k] != b[k] {
-			util.Printf(ctx, "Sri diff %s vs %s for file %s\n", a[k], b[k], k)
-			continue
-		}
-	}
 }

--- a/cmd/packages/main.go
+++ b/cmd/packages/main.go
@@ -176,7 +176,7 @@ func generatePackage(ctx context.Context, p *packages.Package) *outputPackage {
 	out.Filename = p.Filename
 	out.Repository = map[string]string{
 		"type": p.Repository.Repotype,
-		"url":  p.Repository.Url,
+		"url":  p.Repository.URL,
 	}
 	out.Keywords = p.Keywords
 
@@ -189,10 +189,10 @@ func generatePackage(ctx context.Context, p *packages.Package) *outputPackage {
 			"name":  p.Author.Name,
 			"email": p.Author.Email,
 		}
-	} else if p.Author.Url != nil && p.Author.Name != "" {
+	} else if p.Author.URL != nil && p.Author.Name != "" {
 		out.Author = map[string]string{
 			"name": p.Author.Name,
-			"url":  *p.Author.Url,
+			"url":  *p.Author.URL,
 		}
 	} else if p.Author.Name != "" {
 		out.Author = p.Author.Name
@@ -205,10 +205,10 @@ func generatePackage(ctx context.Context, p *packages.Package) *outputPackage {
 	}
 
 	if p.License != nil {
-		if p.License.Url != "" {
+		if p.License.URL != "" {
 			out.License = map[string]string{
 				"name": p.License.Name,
-				"url":  p.License.Url,
+				"url":  p.License.URL,
 			}
 		} else {
 			out.License = p.License.Name

--- a/compress/css.go
+++ b/compress/css.go
@@ -12,16 +12,16 @@ import (
 
 // Extensions the compression handle
 var (
-	CssExt = map[string]bool{
+	CSSExt = map[string]bool{
 		".css": true,
 	}
 
-	BASE_PATH = util.GetEnv("BOT_BASE_PATH")
-	CLEANCSS  = path.Join(BASE_PATH, "tools", "node_modules/clean-css-cli/bin/cleancss")
+	basePath = util.GetEnv("BOT_BASE_PATH")
+	cleanCSS = path.Join(basePath, "tools", "node_modules/clean-css-cli/bin/cleancss")
 )
 
-// Perform a compression of the file
-func CompressCss(ctx context.Context, file string) {
+// CSS performs a compression of the file.
+func CSS(ctx context.Context, file string) {
 	ext := path.Ext(file)
 	outfile := file[0:len(file)-len(ext)] + ".min.css"
 
@@ -43,7 +43,7 @@ func CompressCss(ctx context.Context, file string) {
 		file,
 	}
 
-	cmd := exec.Command(CLEANCSS, args...)
+	cmd := exec.Command(cleanCSS, args...)
 	util.Debugf(ctx, "compress: run %s\n", cmd)
 	out := util.CheckCmd(cmd.CombinedOutput())
 	util.Debugf(ctx, "%s\n", out)

--- a/compress/jpeg.go
+++ b/compress/jpeg.go
@@ -7,14 +7,14 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
-// Extensions the compression handle
+// JpegExt are jpeg extensions the compression handles.
 var JpegExt = map[string]bool{
 	".jpg":  true,
 	".jpeg": true,
 }
 
-// Perform an in-place compression of the file
-func CompressJpeg(ctx context.Context, file string) {
+// Jpeg performs an in-place compression of the file.
+func Jpeg(ctx context.Context, file string) {
 	cmd := exec.Command("jpegoptim", file)
 	util.Debugf(ctx, "compress: run %s\n", cmd)
 	out := util.CheckCmd(cmd.CombinedOutput())

--- a/compress/js.go
+++ b/compress/js.go
@@ -16,12 +16,12 @@ var (
 		".js": true,
 	}
 
-	UGLIFYJS = path.Join(BASE_PATH, "tools", "node_modules/uglify-js/bin/uglifyjs")
-	UGLIFYES = path.Join(BASE_PATH, "tools", "node_modules/uglify-es/bin/uglifyjs")
+	UGLIFYJS = path.Join(basePath, "tools", "node_modules/uglify-js/bin/uglifyjs")
+	UGLIFYES = path.Join(basePath, "tools", "node_modules/uglify-es/bin/uglifyjs")
 )
 
-// Perform a compression of the file
-func CompressJs(ctx context.Context, file string) {
+// Js performs a compression of the file.
+func Js(ctx context.Context, file string) {
 	ext := path.Ext(file)
 	outfile := file[0:len(file)-len(ext)] + ".min.js"
 

--- a/compress/png.go
+++ b/compress/png.go
@@ -7,13 +7,13 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
-// Extensions the compression handle
+// PngExt are png extensions the compression handles.
 var PngExt = map[string]bool{
 	".png": true,
 }
 
-// Perform an in-place compression of the file
-func CompressPng(ctx context.Context, file string) {
+// Png performs an in-place compression of the file.
+func Png(ctx context.Context, file string) {
 	args := []string{
 		"--iterations=60",
 		"--keepchunks=iCCP",

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -19,6 +19,7 @@ func getCredentialsFile() string {
 	return path.Join(home, "google_storage_cdnjs_assets.json")
 }
 
+// GetStorageClient gets the GCP Storage Client.
 func GetStorageClient(ctx context.Context) (*storage.Client, error) {
 	return storage.NewClient(ctx, option.WithCredentialsFile(getCredentialsFile()))
 }

--- a/github/client.go
+++ b/github/client.go
@@ -10,6 +10,7 @@ import (
 	githuboauth2 "golang.org/x/oauth2/github"
 )
 
+// GetClient gets a GitHub client to interact with its API.
 func GetClient() *githubapi.Client {
 	token := util.GetEnv("GITHUB_REPO_API_KEY")
 	ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,11 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20200214034016-1d94cc7ab1c6 // indirect
-	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20200217220822-9197077df867 // indirect
+	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	google.golang.org/api v0.17.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
 )

--- a/go.sum
+++ b/go.sum
@@ -200,7 +200,6 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8ou
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,7 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/g
 github.com/algolia/algoliasearch-client-go v2.25.0+incompatible h1:FGQr9l++u4uQPDXrW8jM5kNJm3Iw5SxEJJtYXSFmPRY=
 github.com/algolia/algoliasearch-client-go/v3 v3.4.0 h1:eeVU30L5DkKUK2q/EjXw+8o7reoK4QB1mS+BG0Jbd4Y=
 github.com/algolia/algoliasearch-client-go/v3 v3.4.0/go.mod h1:d0/D54BCmkwhLxT5VIQBeYLAz2GbZHFX9OptYyohTr0=
+github.com/algolia/algoliasearch-client-go/v3 v3.8.1 h1:Bt9z5gZpPxp/6XoL1pJrzmvJ3uOc0kU1dItHIeufoOc=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,7 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8ou
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -175,6 +176,8 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367 h1:0IiAsCRByjO2QjX7ZPkw5oU9x+n1YqRL802rjC0c3Aw=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -197,6 +200,8 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8ou
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -263,6 +268,8 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56 h1:DFtSed2q3HtNuVazwVDZ4nSRS/JrZEig0gz2BY4VNrg=
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f h1:JcoF/bowzCDI+MXu1yLqQGNO3ibqWsWq+Sk7pOT218w=
+golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,17 +9,18 @@ import (
 )
 
 const (
-	BASE_URL           = "https://metrics.cdnjs.com"
-	METRIC_NEW_VERSION = "new_version"
+	baseURL          = "https://metrics.cdnjs.com"
+	metricNewVersion = "new_version"
 )
 
 func reportMetric(metricType string) {
 	token := util.GetEnv("METRICS_TOKEN")
 	body := strings.NewReader("")
-	_, err := http.Post(fmt.Sprintf("%s/%s?token=%s", BASE_URL, metricType, token), "text/plain", body)
+	_, err := http.Post(fmt.Sprintf("%s/%s?token=%s", baseURL, metricType, token), "text/plain", body)
 	util.Check(err)
 }
 
+// ReportNewVersion reports a new version via http POST.
 func ReportNewVersion() {
-	reportMetric(METRIC_NEW_VERSION)
+	reportMetric(metricNewVersion)
 }

--- a/npm/registry.go
+++ b/npm/registry.go
@@ -49,7 +49,7 @@ type MonthlyDownload struct {
 
 // Gets the protocol, either http or https.
 func getProtocol() string {
-	if util.HasHTTProxy() {
+	if util.HasHTTPProxy() {
 		return "http"
 	}
 	return "https"

--- a/npm/tar.go
+++ b/npm/tar.go
@@ -24,6 +24,7 @@ func removePackageDir(path string) string {
 	return path
 }
 
+// Untar uncompresses a tar at a destination.
 func Untar(dst string, r io.Reader) error {
 	gzr, err := gzip.NewReader(r)
 	if err != nil {
@@ -99,7 +100,7 @@ func Untar(dst string, r io.Reader) error {
 	}
 }
 
-// Extract the tarball url in a temporary location
+// DownloadTar extracts the tarball url into a temporary location.
 func DownloadTar(ctx context.Context, url string) string {
 	dest, err := ioutil.TempDir("", "npmtarball")
 	util.Check(err)

--- a/openssl/sri.go
+++ b/openssl/sri.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
-// CalculateFileSri generates a Subresource Integrity string for a particular file.
-func CalculateFileSri(filename string) string {
+// CalculateFileSRI generates a Subresource Integrity string for a particular file.
+func CalculateFileSRI(filename string) string {
 	dgst, dgstErr := exec.Command("openssl", "dgst", "-sha256", "-binary", filename).Output()
 	util.Check(dgstErr)
 

--- a/openssl/sri.go
+++ b/openssl/sri.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
+// CalculateFileSri generates a Subresource Integrity string for a particular file.
 func CalculateFileSri(filename string) string {
 	dgst, dgstErr := exec.Command("openssl", "dgst", "-sha256", "-binary", filename).Output()
 	util.Check(dgstErr)

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -71,7 +71,7 @@ func stringInObject(key string, object map[string]interface{}) string {
 	}
 }
 
-// Location of the package in the cdnjs repo
+// Path returns the location of the package in the cdnjs repo.
 func (p *Package) Path() string {
 	return path.Join(util.GetCDNJSPackages(), p.Name)
 }
@@ -84,13 +84,13 @@ func (p *Package) Versions() (versions []string) {
 	return p.versions
 }
 
-func (p *Package) CalculateVersionSris(version string) map[string]string {
+func (p *Package) CalculateVersionSRIs(version string) map[string]string {
 	sriFileMap := make(map[string]string)
 
 	for _, relFile := range p.AllFiles(version) {
 		if path.Ext(relFile) == ".js" || path.Ext(relFile) == ".css" {
 			absFile := path.Join(p.Path(), version, relFile)
-			sriFileMap[relFile] = openssl.CalculateFileSri(absFile)
+			sriFileMap[relFile] = openssl.CalculateFileSRI(absFile)
 		}
 	}
 
@@ -135,8 +135,8 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 
 				// warn for files with sizes exceeding max file size
 				size := info.Size()
-				if size > util.MAX_FILE_SIZE {
-					util.Warnf(p.ctx, "file %s ignored due to byte size (%d > %d)", f, size, util.MAX_FILE_SIZE)
+				if size > util.MaxFileSize {
+					util.Warnf(p.ctx, "file %s ignored due to byte size (%d > %d)", f, size, util.MaxFileSize)
 					continue
 				}
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -10,38 +10,48 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
+// Repository represents a repository.
 type Repository struct {
 	Repotype string `json:"type"`
-	Url      string `json:"url"`
+	URL      string `json:"url"`
 }
 
+// Author represents an author.
 type Author struct {
 	Name  string  `json:"name"`
 	Email string  `json:"email"`
-	Url   *string `json:"url,omitempty"`
+	URL   *string `json:"url,omitempty"`
 }
 
+// License represents a license.
 type License struct {
 	Name string `json:"name"`
-	Url  string `json:"url"`
+	URL  string `json:"url"`
 }
 
+// FileMap represents a number of files located
+// under a base path.
 type FileMap struct {
 	BasePath string   `json:"basePath"`
 	Files    []string `json:"files"`
 }
 
+// Autoupdate is used to update particular files from
+// a source type located at a target destination.
 type Autoupdate struct {
 	Source  string     `json:"source"`
 	Target  string     `json:"target"`
 	FileMap *[]FileMap `json:"fileMap,omitempty"`
 }
 
+// Asset associates a number of files as strings
+// with a version.
 type Asset struct {
 	Version string   `json:"version"`
 	Files   []string `json:"files"`
 }
 
+// Package represents a package.
 type Package struct {
 	ctx context.Context
 	// Cache list of versions for the package
@@ -66,9 +76,8 @@ func stringInObject(key string, object map[string]interface{}) string {
 	value := object[key]
 	if str, ok := value.(string); ok {
 		return str
-	} else {
-		return ""
 	}
+	return ""
 }
 
 // Path returns the location of the package in the cdnjs repo.
@@ -76,6 +85,7 @@ func (p *Package) Path() string {
 	return path.Join(util.GetCDNJSPackages(), p.Name)
 }
 
+// Versions gets the versions from git for a particular package.
 func (p *Package) Versions() (versions []string) {
 	if p.versions != nil {
 		return p.versions
@@ -84,6 +94,8 @@ func (p *Package) Versions() (versions []string) {
 	return p.versions
 }
 
+// CalculateVersionSRIs calculates SRIs for the files in
+// a particular package version.
 func (p *Package) CalculateVersionSRIs(version string) map[string]string {
 	sriFileMap := make(map[string]string)
 
@@ -97,6 +109,8 @@ func (p *Package) CalculateVersionSRIs(version string) map[string]string {
 	return sriFileMap
 }
 
+// NpmFileMoveOp represents an operation to move files
+// from a source destination to a target destination.
 type NpmFileMoveOp struct {
 	From string
 	To   string
@@ -152,7 +166,7 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 	return out
 }
 
-// List all files in the version directory
+// AllFiles lists all files in the version directory.
 func (p *Package) AllFiles(version string) []string {
 	out := make([]string, 0)
 
@@ -164,6 +178,7 @@ func (p *Package) AllFiles(version string) []string {
 	return out
 }
 
+// Assets gets all the assets for a particular package.
 func (p *Package) Assets() []Asset {
 	assets := make([]Asset, 0)
 

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -141,7 +141,6 @@ func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {
 				}
 
 				// file is ok
-				util.Debugf(p.ctx, fp+" ok")
 				out = append(out, NpmFileMoveOp{
 					From: path.Join(fileMap.BasePath, f),
 					To:   f,

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -59,7 +59,7 @@ func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 				if valuemap, ok := value.(map[string]interface{}); ok {
 					p.Repository = Repository{
 						Repotype: stringInObject("type", valuemap),
-						Url:      stringInObject("url", valuemap),
+						URL:      stringInObject("url", valuemap),
 					}
 				} else {
 					return nil, errors.New(fmt.Sprintf("failed to parse %s: unsupported Repository", file))
@@ -113,12 +113,12 @@ func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 				if name, ok := value.(string); ok {
 					p.License = &License{
 						Name: name,
-						Url:  "",
+						URL:  "",
 					}
 				} else if valuemap, ok := value.(map[string]interface{}); ok {
 					p.License = &License{
 						Name: stringInObject("name", valuemap),
-						Url:  stringInObject("url", valuemap),
+						URL:  stringInObject("url", valuemap),
 					}
 				} else {
 					return nil, errors.New(fmt.Sprintf("failed to parse %s: unsupported Autoupdate", file))

--- a/packages/sort.go
+++ b/packages/sort.go
@@ -22,6 +22,8 @@ func (a ByVersionAsset) Less(i, j int) bool {
 	return left.Compare(right) == 1
 }
 
+// ByVersionString implements sort.Interface for []string based on
+// a number of semver strings.
 type ByVersionString []string
 
 func (a ByVersionString) Len() int      { return len(a) }

--- a/test/checker/lint_test.go
+++ b/test/checker/lint_test.go
@@ -151,5 +151,5 @@ func TestCheckerLint(t *testing.T) {
 		})
 	}
 
-	testproxy.Shutdown(context.Background())
+	assert.Nil(t, testproxy.Shutdown(context.Background()))
 }

--- a/test/checker/lint_test.go
+++ b/test/checker/lint_test.go
@@ -75,7 +75,7 @@ func TestCheckerLint(t *testing.T) {
 					"target": "git://ff"
 				}
 			}`,
-			expected: ciError(file, ".version should be empty"),
+			expected: ciError(file, ".version should not exist"),
 		},
 
 		{

--- a/test/checker/show_files_test.go
+++ b/test/checker/show_files_test.go
@@ -174,7 +174,7 @@ func fakeNpmHandlerShowFiles(w http.ResponseWriter, r *http.Request) {
 		})
 	case "/" + oversizedFilesPkg + ".tgz":
 		servePackage(w, r, map[string]string{
-			"a.js": strings.Repeat("a", int(util.MAX_FILE_SIZE)+100),
+			"a.js": strings.Repeat("a", int(util.MaxFileSize)+100),
 			"b.js": "ok",
 		})
 	case "/" + unpublishedFieldPkg + ".tgz":

--- a/test/checker/show_files_test.go
+++ b/test/checker/show_files_test.go
@@ -357,5 +357,5 @@ current version: 2.0
 		})
 	}
 
-	testproxy.Shutdown(context.Background())
+	assert.Nil(t, testproxy.Shutdown(context.Background()))
 }

--- a/util/check.go
+++ b/util/check.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 )
 
+// Check enforces that its argument is nil, panicking otherwise.
 func Check(err interface{}) {
 	if err != nil {
 		panic(err)
 	}
 }
 
+// CheckCmd enforces that an error is nil, printing
+// the output and panicking otherwise.
 func CheckCmd(out []byte, err error) string {
 	if err != nil {
 		fmt.Println(string(out))

--- a/util/const.go
+++ b/util/const.go
@@ -10,7 +10,7 @@ const (
 	// MaxFileSize is the file size in bytes accepted by cdnjs (10MiB).
 	MaxFileSize int64 = 10485760
 
-	// MinNPMMonthlyDownloads is the minimum number of monthly downloads
+	// MinNpmMonthlyDownloads is the minimum number of monthly downloads
 	// from npm needed for a library to be accepted into cdnjs.
-	MinNPMMonthlyDownloads = 800
+	MinNpmMonthlyDownloads = 800
 )

--- a/util/const.go
+++ b/util/const.go
@@ -1,15 +1,16 @@
 package util
 
 const (
+	// ImportAllMaxVersions is the maximum number of versions we will import.
 	// When no versions exist in cdnjs and we are trying to import all of them,
 	// limit it to the a few last versions to avoid publishing too many outdated
 	// versions.
-	IMPORT_ALL_MAX_VERSIONS = 10
+	ImportAllMaxVersions = 10
 
-	// Maximum file size in bytes accepted by cdnjs (10MiB).
-	MAX_FILE_SIZE int64 = 10485760
+	// MaxFileSize is the file size in bytes accepted by cdnjs (10MiB).
+	MaxFileSize int64 = 10485760
 
-	// Minimum number of monthly downloads from npm needed
-	// for a library to be accepted into cdnjs.
-	MIN_NPM_MONTHLY_DOWNLOADS = 800
+	// MinNPMMonthlyDownloads is the minimum number of monthly downloads
+	// from npm needed for a library to be accepted into cdnjs.
+	MinNPMMonthlyDownloads = 800
 )

--- a/util/env.go
+++ b/util/env.go
@@ -7,9 +7,11 @@ import (
 )
 
 const (
-	SRI_PATH = "../SRIs"
+	// SRIPath is the path to the directory where calculated SRIs are stored.
+	SRIPath = "../SRIs"
 )
 
+// GetEnv gets an environment variable, panicking if it is empty.
 func GetEnv(name string) string {
 	v := os.Getenv(name)
 	if v == "" {
@@ -18,18 +20,24 @@ func GetEnv(name string) string {
 	return v
 }
 
+// IsDebug returns true if debug mode is enabled based
+// on an environment variable.
 func IsDebug() bool {
 	return os.Getenv("DEBUG") != ""
 }
 
+// GetBotBasePath gets the bot base path from an environment variable.
 func GetBotBasePath() string {
 	return GetEnv("BOT_BASE_PATH")
 }
 
+// GetCDNJSPackages gets the path to the cdnjs libraries.
 func GetCDNJSPackages() string {
 	return path.Join(GetBotBasePath(), "cdnjs", "ajax", "libs")
 }
 
-func HasHTTProxy() bool {
+// HasHTTPProxy returns true if the http proxy environment
+// variable is set.
+func HasHTTPProxy() bool {
 	return os.Getenv("HTTP_PROXY") != ""
 }

--- a/util/git.go
+++ b/util/git.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 )
 
+// UpdateGitRepo git pulls and rebases the repository.
 func UpdateGitRepo(ctx context.Context, gitpath string) {
 	args := []string{"pull", "--rebase"}
 

--- a/util/string.go
+++ b/util/string.go
@@ -1,5 +1,0 @@
-package util
-
-func String(s string) *string {
-	return &s
-}

--- a/util/util.go
+++ b/util/util.go
@@ -6,12 +6,14 @@ import (
 	"os"
 )
 
+// Assert is used to enforce a condition is true.
 func Assert(cond bool) {
 	if !cond {
 		panic("assertion failure")
 	}
 }
 
+// MoveFile moves a file from a source path to destination path.
 func MoveFile(sourcePath, destPath string) error {
 	inputFile, err := os.Open(sourcePath)
 	if err != nil {


### PR DESCRIPTION
- Updated all files to pass `go-lint` checks. Maybe we should run this along with the unit tests when making a PR?

- Minor refactoring to make files consistent / more readable.

- Removed unused file `util/string.go`, removed unused function `GetRobotcdnjsBucket()`.

Note: I also updated the `go.mod` and `go.sum` files (VSCode wanted to change them), but had to remove `-mod=readonly` from the `Makefile` temporarily in order to `make` after changing them. Not sure if this is a problem!
