### PR TITLE
remove legacy npm fields

### DIFF
--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -241,13 +241,6 @@ func lintPackage(pckgPath string) {
 		err(ctx, shouldNotExist(".version"))
 	}
 
-	if pckg.NpmName != nil {
-		err(ctx, shouldNotExist(".NpmName"))
-	}
-	if len(pckg.NpmFileMap) > 0 {
-		err(ctx, shouldNotExist(".NpmFileMap"))
-	}
-
 	if pckg.Autoupdate != nil {
 		switch pckg.Autoupdate.Source {
 		case "npm":

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -66,7 +66,6 @@ type Package struct {
 	Keywords    []string
 	Repository  Repository
 	Filename    string
-	NpmName     *string
 	NpmFileMap  []FileMap
 	License     *License
 	Autoupdate  *Autoupdate

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -76,38 +76,6 @@ func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 					return nil, errors.New(fmt.Sprintf("failed to parse %s: unsupported Keywords", file))
 				}
 			}
-		case "npmName":
-			{
-				str := value.(string)
-				p.NpmName = &str
-				// the package refers to a package on npm, we can set the autoupdate
-				// method to npm
-				p.Autoupdate = &Autoupdate{
-					Source: "npm",
-					Target: str,
-				}
-			}
-		case "npmFileMap":
-			{
-				if values, ok := value.([]interface{}); ok {
-					p.NpmFileMap = make([]FileMap, 0)
-					for _, rawValue := range values {
-						value := rawValue.(map[string]interface{})
-						fileMap := FileMap{
-							BasePath: stringInObject("basePath", value),
-							Files:    make([]string, 0),
-						}
-
-						for _, file := range value["files"].([]interface{}) {
-							fileMap.Files = append(fileMap.Files, file.(string))
-						}
-
-						p.NpmFileMap = append(p.NpmFileMap, fileMap)
-					}
-				} else {
-					return nil, errors.New(fmt.Sprintf("failed to parse %s: unsupported npmFileMap", file))
-				}
-			}
 		case "license":
 			{
 				if name, ok := value.(string); ok {
@@ -164,7 +132,7 @@ func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 		case "devDependencies":
 			// ignore
 		default:
-			util.Printf(ctx, "unknown field %s\n", key)
+			util.Errf(ctx, "unknown field %s", key)
 		}
 	}
 

--- a/test/checker/lint_test.go
+++ b/test/checker/lint_test.go
@@ -147,8 +147,9 @@ func TestCheckerLint(t *testing.T) {
 				]
 
 			}`,
-			expected: ciError(file, ".NpmName should not exist") +
-				ciError(file, ".NpmFileMap should not exist"),
+			expected: ciError(file, "unknown field npmName") +
+				ciError(file, "unknown field npmFileMap") +
+				ciError(file, ".autoupdate should not be null. Package will never auto-update"),
 		},
 	}
 


### PR DESCRIPTION
We technically this rely on `NpmFileMap` internally, but we are making progress.