### PR TITLE
allow linting multiple packages

### DIFF
--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -34,7 +34,9 @@ func main() {
 	switch subcommand := flag.Arg(0); subcommand {
 	case "lint":
 		{
-			lintPackage(flag.Arg(1))
+			for _, path := range flag.Args()[1:] {
+				lintPackage(path)
+			}
 
 			if errCount > 0 {
 				os.Exit(1)


### PR DESCRIPTION
We can now use `find . -name "*.json" | xargs checker lint`