### PR TITLE
Quick fix for npm `no latest tag` issue

### DIFF
--- a/npm/registry.go
+++ b/npm/registry.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cdnjs/tools/sentry"
 	"github.com/cdnjs/tools/util"
 )
 
@@ -117,7 +118,11 @@ func GetVersions(name string) ([]Version, string) {
 	// get latest version according to npm
 	latest, ok := r.DistTags["latest"]
 	if !ok {
-		panic(fmt.Sprintf("no latest tag for npm package %s", name))
+		// Quick fix: log in sentry when npm registry does not have latest
+		// such as in the case of https://registry.npmjs.org/angularjs-ie8-build.
+
+		sentry.NotifyError(fmt.Errorf("no latest tag for npm package %s", name))
+		//panic(fmt.Sprintf("no latest tag for npm package %s", name))
 	}
 
 	return versions, latest

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -24,8 +24,13 @@ func PanicHandler() {
 	err := recover()
 
 	if err != nil {
-		sentry.CurrentHub().Recover(err)
-		sentry.Flush(time.Second * 5)
+		NotifyError(err)
 	}
 	panic(err)
+}
+
+// NotifyError notifies sentry of an error
+func NotifyError(err interface{}) {
+	sentry.CurrentHub().Recover(err)
+	sentry.Flush(time.Second * 5)
 }


### PR DESCRIPTION
- notify via sentry