### PR TITLE
Add -no-pull option to autoupdate

### DIFF
--- a/cmd/autoupdate/README.md
+++ b/cmd/autoupdate/README.md
@@ -2,3 +2,6 @@
 
 ## -no-update
 If the flag is set, the autoupdater will not commit or push to git. This is used for local testing purposes.
+
+## -no-pull
+If the flag is set, the autoupdater will pull from git.

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -49,15 +49,19 @@ func main() {
 	defer sentry.PanicHandler()
 
 	var noUpdate bool
+	var noPull bool
 	flag.BoolVar(&noUpdate, "no-update", false, "if set, the autoupdater will not commit or push to git")
+	flag.BoolVar(&noPull, "no-pull", false, "if set, the autoupdater will not pull from git")
 	flag.Parse()
 
 	if util.IsDebug() {
-		fmt.Printf("Running in debug mode (no-update=%t)\n", noUpdate)
+		fmt.Printf("Running in debug mode (no-update=%t, no-pull=%t)\n", noUpdate, noPull)
 	}
 
-	util.UpdateGitRepo(defaultCtx, cdnjsPath)
-	util.UpdateGitRepo(defaultCtx, packagesPath)
+	if !noPull {
+		util.UpdateGitRepo(defaultCtx, cdnjsPath)
+		util.UpdateGitRepo(defaultCtx, packagesPath)
+	}
 
 	for _, f := range getPackages(defaultCtx) {
 		// create context with file path prefix, standard debug logger


### PR DESCRIPTION
Without this option, autoupdate will panic if the "cdnjs" directory
isn't a git repository, in addition, it is overkill to pull if the repo
was just cloned, and it can take a long time as the cdnjs repo is very
big.