### PR TITLE
Only commit cdnjs package.json if changed

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -87,7 +87,9 @@ func main() {
 
 		if !noUpdate && len(newVersionsToCommit) > 0 {
 			commitNewVersions(ctx, newVersionsToCommit)
-			commitPackageVersion(ctx, pckg, latestVersion, f)
+			if *pckg.Version != latestVersion {
+				commitPackageVersion(ctx, pckg, latestVersion, f)
+			}
 		}
 	}
 


### PR DESCRIPTION
Before autoupdate would panic, if a old version was added, as it would
try to commit a unchanged package.json.

Fix #64

---
This hasn't been tested, but why wouldn't it work?