### PR TITLE
Don't add versions ignored by git

### DIFF
--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -115,6 +115,11 @@ func doUpdateGit(ctx context.Context, pckg *packages.Package, gitpath string, ve
 			continue
 		}
 
+		if util.IsPathIgnoredByGit(ctx, util.GetCDNJSPath(), pckgpath) {
+			util.Debugf(ctx, "%s is ignored by git; aborting\n", pckgpath)
+			continue
+		}
+
 		util.Check(os.MkdirAll(pckgpath, os.ModePerm))
 
 		if len(filesToCopy) > 0 {

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var (
-	basePath     = util.GetEnv("BOT_BASE_PATH")
+	basePath     = util.GetBotBasePath()
 	packagesPath = path.Join(basePath, "packages", "packages")
 	cdnjsPath    = path.Join(basePath, "cdnjs")
 

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -24,7 +24,7 @@ func init() {
 var (
 	basePath     = util.GetBotBasePath()
 	packagesPath = path.Join(basePath, "packages", "packages")
-	cdnjsPath    = path.Join(basePath, "cdnjs")
+	cdnjsPath    = util.GetCDNJSPath()
 
 	// initialize standard debug logger
 	logger = util.GetStandardLogger()

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -83,6 +83,11 @@ func doUpdateNpm(ctx context.Context, pckg *packages.Package, versions []npm.Ver
 			continue
 		}
 
+		if util.IsPathIgnoredByGit(ctx, util.GetCDNJSPath(), pckgpath) {
+			util.Debugf(ctx, "%s is ignored by git; aborting\n", pckgpath)
+			continue
+		}
+
 		util.Check(os.MkdirAll(pckgpath, os.ModePerm))
 
 		tarballDir := npm.DownloadTar(ctx, version.Tarball)

--- a/compress/css.go
+++ b/compress/css.go
@@ -16,7 +16,7 @@ var (
 		".css": true,
 	}
 
-	basePath = util.GetEnv("BOT_BASE_PATH")
+	basePath = util.GetBotBasePath()
 	cleanCSS = path.Join(basePath, "tools", "node_modules/clean-css-cli/bin/cleancss")
 )
 

--- a/util/env.go
+++ b/util/env.go
@@ -36,9 +36,14 @@ func GetBotBasePath() string {
 	return GetEnv("BOT_BASE_PATH")
 }
 
+// GetCDNJSPath gets the path to the cdnjs repo.
+func GetCDNJSPath() string {
+	return path.Join(GetBotBasePath(), "cdnjs")
+}
+
 // GetCDNJSPackages gets the path to the cdnjs libraries.
 func GetCDNJSPackages() string {
-	return path.Join(GetBotBasePath(), "cdnjs", "ajax", "libs")
+	return path.Join(GetCDNJSPath(), "ajax", "libs")
 }
 
 // HasHTTPProxy returns true if the http proxy environment

--- a/util/git.go
+++ b/util/git.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"os/exec"
+	"strings"
 )
 
 // UpdateGitRepo git pulls and rebases the repository.
@@ -13,4 +14,24 @@ func UpdateGitRepo(ctx context.Context, gitpath string) {
 	cmd.Dir = gitpath
 	Debugf(ctx, "%s: run %s\n", gitpath, cmd)
 	CheckCmd(cmd.CombinedOutput())
+}
+
+// IsPathIgnoredByGit determines if a path is git ignored.
+func IsPathIgnoredByGit(ctx context.Context, gitpath string, path string) bool {
+	// We don't know if "path" is a file or a directory, so let's try with and without /
+	return isPathIgnoredByGit(ctx, gitpath, path) || isPathIgnoredByGit(ctx, gitpath, path+"/")
+}
+
+func isPathIgnoredByGit(ctx context.Context, gitpath string, path string) bool {
+	// We need a relative path, so let's remove "gitpath"
+	path = strings.TrimPrefix(path, gitpath)
+	// In case "path" is a absolute path, we need to remove "/" afterwards to get a relative path
+	path = strings.TrimPrefix(path, "/")
+	args := []string{"check-ignore", "--quiet", "--no-index", path}
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = gitpath
+	Debugf(ctx, "%s: run %s\n", gitpath, cmd)
+
+	return cmd.Run() == nil
 }


### PR DESCRIPTION
autoupdate would panic as `git add` exit with a non-zero exit status if
the path is ignored.

Fix #58

---

~~This hasn't been tested, but the dirty fix was tested (https://github.com/klausenbusk/tools/compare/4268b20...5054f34), this is mostly a refactor of the dirty fix.~~ **Edit** see: https://github.com/cdnjs/tools/pull/67#issuecomment-653932077