### PR TITLE
Enforce Semver

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/blang/semver"
 	"github.com/cdnjs/tools/compress"
 	"github.com/cdnjs/tools/metrics"
 	"github.com/cdnjs/tools/packages"
@@ -85,10 +86,16 @@ func main() {
 			}
 		}
 
-		if !noUpdate && len(newVersionsToCommit) > 0 {
-			commitNewVersions(ctx, newVersionsToCommit)
-			if pckg.Version == nil || *pckg.Version != latestVersion {
-				commitPackageVersion(ctx, pckg, latestVersion, f)
+		if !noUpdate {
+			if len(newVersionsToCommit) > 0 {
+				commitNewVersions(ctx, newVersionsToCommit)
+			}
+			if _, err := semver.Parse(latestVersion); err != nil {
+				util.Debugf(ctx, "ignoring invalid latest version: %s\n", latestVersion)
+			} else {
+				if pckg.Version == nil || *pckg.Version != latestVersion {
+					commitPackageVersion(ctx, pckg, latestVersion, f)
+				}
 			}
 		}
 	}

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -16,7 +16,7 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	var newVersionsToCommit []newVersionToCommit
 
 	existingVersionSet := pckg.Versions()
-	npmVersions, latestNpmVersion := npm.GetVersions(pckg.Autoupdate.Target)
+	npmVersions, latestNpmVersion := npm.GetVersions(ctx, pckg.Autoupdate.Target)
 	lastExistingVersion := npm.GetMostRecentExistingVersion(ctx, existingVersionSet, npmVersions)
 
 	if lastExistingVersion != nil {

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -97,7 +97,9 @@ func showFiles(pckgPath string) {
 			}
 
 			// download into temp dir
-			downloadDir = npm.DownloadTar(ctx, npmVersions[0].Tarball)
+			if len(versions) > 0 {
+				downloadDir = npm.DownloadTar(ctx, npmVersions[0].Tarball)
+			}
 
 			// set err string if no versions
 			noVersionsErr = "no version found on npm"

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -88,7 +88,7 @@ func showFiles(pckgPath string) {
 	case "npm":
 		{
 			// get npm versions and sort
-			npmVersions, _ := npm.GetVersions(pckg.Autoupdate.Target)
+			npmVersions, _ := npm.GetVersions(ctx, pckg.Autoupdate.Target)
 			sort.Sort(npm.ByTimeStamp(npmVersions))
 
 			// cast to interface

--- a/git/git.go
+++ b/git/git.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/cdnjs/tools/packages"
 	"github.com/cdnjs/tools/util"
 )
@@ -40,10 +41,16 @@ func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache st
 
 	gitVersions := make([]Version, 0)
 	for _, tag := range gitTags {
+		version := strings.TrimPrefix(tag, "v")
+
+		if _, err := semver.Parse(version); err != nil {
+			util.Debugf(ctx, "ignoring non-semver git version: %s\n", version)
+			continue
+		}
 
 		gitVersions = append(gitVersions, Version{
 			Tag:       tag,
-			Version:   strings.TrimPrefix(tag, "v"),
+			Version:   version,
 			TimeStamp: packages.GitTimeStamp(ctx, packageGitcache, tag),
 		})
 	}

--- a/test/checker/show_files_test.go
+++ b/test/checker/show_files_test.go
@@ -21,11 +21,11 @@ const (
 	oversizedFilesPkg   = "oversizePkg"
 	unpublishedFieldPkg = "unpublishedPkg"
 	sortByTimeStampPkg  = "sortByTimePkg"
-	timeStamp1          = "1.0"
-	timeStamp2          = "2.0"
-	timeStamp3          = "3.0"
-	timeStamp4          = "4.0"
-	timeStamp5          = "5.0"
+	timeStamp1          = "1.0.0"
+	timeStamp2          = "2.0.0"
+	timeStamp3          = "3.0.0"
+	timeStamp4          = "4.0.0"
+	timeStamp5          = "5.0.0"
 )
 
 type ShowFilesTestCase struct {
@@ -142,41 +142,41 @@ func fakeNpmHandlerShowFiles(w http.ResponseWriter, r *http.Request) {
 	case "/" + sortByTimeStampPkg:
 		fmt.Fprint(w, `{
 			"versions": {
-				"1.0": {
+				"1.0.0": {
 					"dist": {
 						"tarball": "http://registry.npmjs.org/`+timeStamp1+`.tgz"
 					}
 				},
-				"2.0": {
+				"2.0.0": {
 					"dist": {
 						"tarball": "http://registry.npmjs.org/`+timeStamp2+`.tgz"
 					}
 				},
-				"3.0": {
+				"3.0.0": {
 					"dist": {
 						"tarball": "http://registry.npmjs.org/`+timeStamp3+`.tgz"
 					}
 				},
-				"4.0": {
+				"4.0.0": {
 					"dist": {
 						"tarball": "http://registry.npmjs.org/`+timeStamp4+`.tgz"
 					}
 				},
-				"5.0": {
+				"5.0.0": {
 					"dist": {
 						"tarball": "http://registry.npmjs.org/`+timeStamp5+`.tgz"
 					}
 				}
 			},
 			 "time": {
-				"2.0": "2019-12-30T19:39:27.425Z",
-				"3.0": "2019-12-30T19:38:27.425Z",
-				"1.0": "2018-12-30T19:39:27.425Z",
-				"5.0": "2017-12-30T19:39:27.425Z",
-    			"4.0": "2017-11-30T19:39:27.425Z"
+				"2.0.0": "2019-12-30T19:39:27.425Z",
+				"3.0.0": "2019-12-30T19:38:27.425Z",
+				"1.0.0": "2018-12-30T19:39:27.425Z",
+				"5.0.0": "2017-12-30T19:39:27.425Z",
+    			"4.0.0": "2017-11-30T19:39:27.425Z"
 			},
 			"dist-tags": {
-				"latest": "3.0"
+				"latest": "3.0.0"
 			}
 		}`)
 	case "/" + jsFilesPkg + ".tgz":
@@ -328,17 +328,17 @@ c.js
 			}`,
 			expected: `
 
-most recent version: 2.0
+most recent version: 2.0.0
 
 ` + "```" + `
 2.js
 ` + "```" + `
 
 4 last version(s):
-- 3.0: 1 file(s) matched :heavy_check_mark:
-- 1.0: 1 file(s) matched :heavy_check_mark:
-- 5.0: 1 file(s) matched :heavy_check_mark:
-- 4.0: 1 file(s) matched :heavy_check_mark:
+- 3.0.0: 1 file(s) matched :heavy_check_mark:
+- 1.0.0: 1 file(s) matched :heavy_check_mark:
+- 5.0.0: 1 file(s) matched :heavy_check_mark:
+- 4.0.0: 1 file(s) matched :heavy_check_mark:
 `,
 		},
 	}


### PR DESCRIPTION
Addressing the [ace issue](https://github.com/cdnjs/packages/issues/331).

We should only accept semver for all git and npm versions. 

Also, we should update the `latest` version whenever a change has been found, regardless of if there are new versions to commit.