### PR TITLE
handle signals in autoupdater

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In `tools/` run `npm install`.
 
 - [jpegoptim](https://www.kokkonen.net/tjko/projects.html)
 - [zopflipng](https://github.com/google/zopfli)
+- [brotli](https://github.com/google/brotli) (Linux)
 
 ## Setup a local environment
 

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -100,11 +100,6 @@ func main() {
 			}
 		}
 
-		if pckg.Autoupdate.Source == "git" {
-			util.Debugf(ctx, "running git update")
-			newVersionsToCommit, latestVersion = updateGit(ctx, pckg)
-		}
-
 		if !noUpdate {
 			if len(newVersionsToCommit) > 0 {
 				commitNewVersions(ctx, newVersionsToCommit)

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -101,6 +101,7 @@ func main() {
 			if !noUpdate {
 				if len(newVersionsToCommit) > 0 {
 					commitNewVersions(ctx, newVersionsToCommit)
+					packages.GitPush(ctx, cdnjsPath)
 					//writeNewVersionsToKV(defaultCtx, newVersionsToCommit)
 				}
 				if _, err := semver.Parse(latestVersion); err != nil {
@@ -110,13 +111,10 @@ func main() {
 					util.Check(err)
 					if destpckg.Version == nil || *destpckg.Version != latestVersion {
 						commitPackageVersion(ctx, pckg, latestVersion, f)
+						packages.GitPush(ctx, cdnjsPath)
 					}
 				}
 			}
-		}
-
-		if !noUpdate {
-			packages.GitPush(defaultCtx, cdnjsPath)
 		}
 	}
 }


### PR DESCRIPTION
If the bot receives SIGINT/SIGTERM, it will not exit until it is finished processing its current package.  This will help avoid inconsistent KV states.

(this has not been tested)