### PR TITLE
Fix `latest` version to allow non-semver packages to update

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -131,7 +131,7 @@ func main() {
 }
 
 // Gets the latest stable version by time stamp. A  "stable" version is
-// considered to be a version contains no pre-releases.
+// considered to be a version that contains no pre-releases.
 // If no latest stable version is found (ex. all are non-semver), a nil *string
 // will be returned.
 func getLatestStableVersion(versions []version) *string {

--- a/git/git.go
+++ b/git/git.go
@@ -40,7 +40,7 @@ func (g Version) GetTimeStamp() time.Time {
 
 // GetVersions gets all of the versions associated with a git repo,
 // as well as the latest version.
-func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache string) ([]Version, string) {
+func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache string) ([]Version, *string) {
 	gitTags := packages.GitTags(ctx, packageGitcache)
 	util.Debugf(ctx, "found tags in git: %s\n", gitTags)
 
@@ -61,7 +61,7 @@ func GetVersions(ctx context.Context, pckg *packages.Package, packageGitcache st
 	}
 
 	if latest := GetMostRecentVersion(gitVersions); latest != nil {
-		return gitVersions, latest.Version
+		return gitVersions, &latest.Version
 	}
-	return gitVersions, ""
+	return gitVersions, nil
 }

--- a/git/sort.go
+++ b/git/sort.go
@@ -17,18 +17,21 @@ func (a ByTimeStamp) Less(i, j int) bool {
 }
 
 // GetMostRecentExistingVersion gets the most recent git.Version based on time stamp
-// that is currently downloaded.
-func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string, gitVersions []Version) *Version {
+// that is currently downloaded as well as all existing versions in git.Version form.
+func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string, gitVersions []Version) (*Version, []Version) {
 	// create map for fast lookups
 	gitMap := make(map[string]Version)
 	for _, v := range gitVersions {
 		gitMap[v.Version] = v
 	}
 
+	var allExisting []Version
+
 	// find most recent version
 	var mostRecent *Version
 	for _, existingVersion := range existingVersions {
 		if version, ok := gitMap[existingVersion]; ok {
+			allExisting = append(allExisting, version)
 			if mostRecent == nil || version.TimeStamp.After(mostRecent.TimeStamp) {
 				mostRecent = &version // new most recent found
 			}
@@ -37,7 +40,7 @@ func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string
 		util.Debugf(ctx, "existing version not found on git: %s", existingVersion)
 	}
 
-	return mostRecent
+	return mostRecent, allExisting
 }
 
 // GetMostRecentVersion gets the latest version in git based on time stamp.

--- a/npm/sort.go
+++ b/npm/sort.go
@@ -17,18 +17,21 @@ func (a ByTimeStamp) Less(i, j int) bool {
 }
 
 // GetMostRecentExistingVersion gets the most recent npm.Version based on time stamp
-// that is currently downloaded.
-func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string, npmVersions []Version) *Version {
+// that is currently downloaded as well as all existing versions in npm.Version form.
+func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string, npmVersions []Version) (*Version, []Version) {
 	// create map for fast lookups
 	npmMap := make(map[string]Version)
 	for _, v := range npmVersions {
 		npmMap[v.Version] = v
 	}
 
+	var allExisting []Version
+
 	// find most recent version
 	var mostRecent *Version
 	for _, existingVersion := range existingVersions {
 		if version, ok := npmMap[existingVersion]; ok {
+			allExisting = append(allExisting, version)
 			if mostRecent == nil || version.TimeStamp.After(mostRecent.TimeStamp) {
 				mostRecent = &version // new most recent found
 			}
@@ -37,5 +40,5 @@ func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string
 		util.Debugf(ctx, "existing version not found on npm: %s", existingVersion)
 	}
 
-	return mostRecent
+	return mostRecent, allExisting
 }


### PR DESCRIPTION
Addressing #104 .

- The `latest` version will be the most recent stable semver version, where stable is considered a semver version that is *not* a pre-release. If there is no latest stable semver version, the `latest` version is the most recent version by time stamp, regardless of its format.

Note that currently there the code is not making use of the npm `latest` tag. To determine if a semver version `s` is not a pre-release, there is a check `len(s.Pre) == 0`. I am not sure if this is sufficient for corner cases. Also, build metadata is ignored, so a version with build data could potentially be considered stable.

