### PR TITLE
etag mirroring nginx conf

### DIFF
--- a/kv/update.go
+++ b/kv/update.go
@@ -2,12 +2,12 @@ package kv
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
+	"time"
 
 	"github.com/cdnjs/tools/compress"
 	"github.com/cdnjs/tools/util"
@@ -57,12 +57,14 @@ func updateCompressedFilesRequests(ctx context.Context, pkg, version, fullPathTo
 		}
 
 		// set metadata
-		hash := md5.Sum(bytes)
-		etag := hex.EncodeToString(hash[:])
-		lastModified := info.ModTime().Format(http.TimeFormat)
+		lastModifiedTime := info.ModTime()
+		lastModifiedSeconds := lastModifiedTime.UnixNano() / int64(time.Second)
+		lastModifiedStr := lastModifiedTime.Format(http.TimeFormat)
+		etag := fmt.Sprintf("W/%x-%x", lastModifiedSeconds, info.Size())
+
 		meta := &Metadata{
 			ETag:         etag,
-			LastModified: lastModified,
+			LastModified: lastModifiedStr,
 		}
 
 		if _, ok := doNotCompress[ext]; ok {


### PR DESCRIPTION
- etag will now mirror [what nginx is doing](http://lxr.nginx.org/source/src/http/ngx_http_core_module.c#1619), which is simply a weak etag as follows:

`"W/<seconds of last modified as hex>-<uncompressed content length as hex>"`

This has been tested [here](https://play.golang.org/p/n2X2u5mZaiR) in the Go Playground.

```
package main

import (
	"fmt"
	"time"
	"net/http"
)

func main() {
	// https://staging.speedcdnjs.com/ajax/libs/jquery/3.5.1/jquery.min.js
	// ETag: W/"5eb0a23d-15d84"
	// This is W/"<seconds of last modified>-<uncompressed content length>	
	
	t, err := http.ParseTime("Mon, 04 May 2020 23:16:13 GMT")
	if err != nil { panic(err) }
	
	var contentLength int64 = 89476
	seconds := t.UnixNano() / int64(time.Second)
	
	fmt.Println(fmt.Sprintf("W/%x-%x", seconds, contentLength) == "W/5eb0a23d-15d84") 
}
```