### PR TITLE
Tool to view distribution of properties within packages JSON files

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -28,7 +28,7 @@ func init() {
 
 var (
 	basePath     = util.GetBotBasePath()
-	packagesPath = path.Join(basePath, "packages", "packages")
+	packagesPath = util.GetPackagesPath()
 	cdnjsPath    = util.GetCDNJSPath()
 
 	// initialize standard debug logger
@@ -37,12 +37,6 @@ var (
 	// default context (no logger prefix)
 	defaultCtx = util.ContextWithEntries(util.GetStandardEntries("", logger)...)
 )
-
-func getPackages(ctx context.Context) []string {
-	list, err := util.ListFilesGlob(ctx, packagesPath, "*/*.json")
-	util.Check(err)
-	return list
-}
 
 type version interface {
 	Get() string             // Get the version.
@@ -88,7 +82,7 @@ func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGTERM)
 
-	for _, f := range getPackages(defaultCtx) {
+	for _, f := range packages.GetPackagesJSONFiles(defaultCtx) {
 		// create context with file path prefix, standard debug logger
 		ctx := util.ContextWithEntries(util.GetStandardEntries(f, logger)...)
 

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -16,15 +16,24 @@ Outputs the distribution of packages that contain a particular JSON property (or
 
 For example:
 
-```make checker && ./bin/checker print-meta author email```
+```
+make checker && ./bin/checker print-meta author email
+```
 
 This will find the the distribution of packages that contain both properties:
 
-`{"author": {"email" : <>}}`
+```
+{"author": {"email" : <>}}
+```
 
 ones that contain no `email`:
-`{"author": <>}` 
+
+```
+{"author": <>}
+```
 
 and ones that do not have `author` at all:
 
-`{}`
+```
+{}
+```

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -14,4 +14,9 @@ Output how many package files match and whether they will be ignored for a numbe
 
 Outputs the distribution of packages that contain a particular JSON property (or sub-property).
 
+For example:
+
 ```make checker && ./bin/checker print-meta author email```
+
+This will find the the distribution of packages that contain `{"author": {"email" : <>}}`, as
+well as note the ones that contain no `email` (`{"author": <>}`) and ones that do not have `author` whatsoever (`{}`).

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -18,5 +18,13 @@ For example:
 
 ```make checker && ./bin/checker print-meta author email```
 
-This will find the the distribution of packages that contain `{"author": {"email" : <>}}`, as
-well as note the ones that contain no `email` (`{"author": <>}`) and ones that do not have `author` whatsoever (`{}`).
+This will find the the distribution of packages that contain both properties:
+
+`{"author": {"email" : <>}}`
+
+ones that contain no `email`:
+`{"author": <>}` 
+
+and ones that do not have `author` at all:
+
+`{}`

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -9,3 +9,7 @@ Checks that a package is correctly configured based on its JSON.
 ## `show-files`
 
 Output how many package files match and whether they will be ignored for a number of latest npm/git versions.
+
+## `print-meta`
+
+Outputs a respective property from all package metadata.

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -10,14 +10,14 @@ Checks that a package is correctly configured based on its JSON.
 
 Output how many package files match and whether they will be ignored for a number of latest npm/git versions.
 
-## `print-meta`
+## `meta`
 
 Outputs the distribution of packages that contain a particular JSON property (or sub-property).
 
 For example:
 
 ```
-make checker && ./bin/checker print-meta author email
+make checker && ./bin/checker meta author email
 ```
 
 This will find the the distribution of packages that contain both properties:

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -12,4 +12,6 @@ Output how many package files match and whether they will be ignored for a numbe
 
 ## `print-meta`
 
-Outputs a respective property from all package metadata.
+Outputs the distribution of packages that contain a particular JSON property (or sub-property).
+
+```make checker && ./bin/checker print-meta author email```

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -112,7 +112,7 @@ func printMeta(nestedFields []string) {
 				continue
 			}
 
-			util.Infof(ctx, "FAIL %s\n", cur)
+			util.Infof(ctx, "MISSING %s\n", cur)
 			missingTypes[cur]++
 			break
 		}

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -89,7 +89,6 @@ func printMeta(nestedFields []string) {
 		var cur string
 
 		for i := 0; i <= len(nestedFields); i++ {
-
 			u := unknown
 			if i < len(nestedFields) {
 				cur += "." + nestedFields[i]
@@ -101,6 +100,7 @@ func printMeta(nestedFields []string) {
 						continue
 					}
 				default:
+					// assuming only strings and keys that map to strings
 					panic(fmt.Sprintf("(%s) - unexpected type: %s", f, reflect.TypeOf(unknown)))
 				}
 			}

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -55,7 +55,12 @@ func main() {
 		}
 	case "print-meta":
 		{
-			printMeta(flag.Arg(1))
+			field := flag.Arg(1)
+			if field == "" {
+				panic("field cannot be empty")
+			}
+
+			printMeta(field)
 		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -54,7 +54,7 @@ func main() {
 				os.Exit(1)
 			}
 		}
-	case "print-meta":
+	case "meta":
 		{
 			fields := flag.Args()[1:]
 			if len(fields) == 0 {

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -11,6 +11,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+// GetPackagesJSONFiles gets the paths of the human-readable JSON files from within the `packagesPath`.
+func GetPackagesJSONFiles(ctx context.Context) []string {
+	list, err := util.ListFilesGlob(ctx, util.GetPackagesPath(), "*/*.json")
+	util.Check(err)
+	return list
+}
+
 // ReadPackageJSON parses a JSON file into a Package.
 func ReadPackageJSON(ctx context.Context, file string) (*Package, error) {
 	data, err := ioutil.ReadFile(file)

--- a/util/env.go
+++ b/util/env.go
@@ -41,6 +41,11 @@ func GetCDNJSPath() string {
 	return path.Join(GetBotBasePath(), "cdnjs")
 }
 
+// GetPackagesPath gets the path to the packages repo.
+func GetPackagesPath() string {
+	return path.Join(GetBotBasePath(), "packages", "packages")
+}
+
 // GetCDNJSPackages gets the path to the cdnjs libraries.
 func GetCDNJSPackages() string {
 	return path.Join(GetCDNJSPath(), "ajax", "libs")


### PR DESCRIPTION
For example:
```
make checker && ./bin/checker meta licenses
```

```
Summary of Types
licenses: SUCCESS (136): []interface {}
licenses: MISSING (3753): .licenses
```

We can see there are 136 packages that have the `licenses` property in their `cdnjs/packages/packages/...` human-readable JSON files. (We still need to handle licenses).

Another example:
```
make checker && ./bin/checker meta author email
```

```
Summary of Types
author: SUCCESS (666): string
author: MISSING (2775): .author.email
author: MISSING (448): .author
```

Here, there are 666 packages that contain the `email` property within `author`, 2775 packages that have `author` but are missing the nested `email` property, and 448 packages that do not have `author` whatsoever. For the successes, there is only one type of the `email` value, which is just a `string`. If there were other types they would appear as separate `SUCCESS` entries.
