### PR TITLE
KV Tool to check package/version metadata

### DIFF
--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -6,8 +6,20 @@ Tools to test our Workers KV namespace.
 
 Inserts packages from disk to KV. Package files and version metadata will be pushed to KV.
 
+For example:
+
+```
+make kv && ./bin/kv upload jquery mathjax fontawesome
+```
+
 ## `upload-meta`
 
 Inserts respective package metadata JSON files from disk to KV. 
 
 **Make sure the bot is not running to avoid KV write race conditions for the latest package version**.
+
+For example:
+
+```
+make kv && ./bin/kv upload-meta jquery mathjax fontawesome
+```

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -6,8 +6,6 @@ Tools to test our Workers KV namespace.
 
 Inserts packages from disk to KV. Package files and version metadata will be pushed to KV.
 
-For example:
-
 ```
 make kv && ./bin/kv upload jquery mathjax fontawesome
 ```
@@ -18,8 +16,14 @@ Inserts respective package metadata JSON files from disk to KV.
 
 **Make sure the bot is not running to avoid KV write race conditions for the latest package version**.
 
-For example:
-
 ```
 make kv && ./bin/kv upload-meta jquery mathjax fontawesome
+```
+
+## `meta`
+
+Gets all metadata associated with a package in KV.
+
+```
+make kv && ./bin/kv get-meta jquery
 ```

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -25,5 +25,5 @@ make kv && ./bin/kv upload-meta jquery mathjax fontawesome
 Gets all metadata associated with a package in KV.
 
 ```
-make kv && ./bin/kv get-meta jquery
+make kv && ./bin/kv meta jquery
 ```

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -40,6 +40,15 @@ func main() {
 
 			kv.InsertMetadataFromDisk(logger, pckgs)
 		}
+	case "meta":
+		{
+			pckg := flag.Arg(1)
+			if pckg == "" {
+				panic("no package specified")
+			}
+
+			kv.OutputAllMeta(logger, pckgs)
+		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))
 	}

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -47,7 +47,7 @@ func main() {
 				panic("no package specified")
 			}
 
-			kv.OutputAllMeta(logger, pckgs)
+			kv.OutputAllMeta(logger, pckg)
 		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -58,6 +58,27 @@ func Read(key, namespaceID string) ([]byte, error) {
 	return api.ReadWorkersKV(context.Background(), namespaceID, key)
 }
 
+// ListByPrefix returns all KVs that start with a prefix.
+// Note this function is used for testing only. For practical uses,
+// use the Cursor option to avoid being limited to 1000 KVs at a time.
+func ListByPrefix(prefix, namespaceID string) ([]string, error) {
+	o := cloudflare.ListWorkersKVsOptions{
+		Prefix: &prefix,
+	}
+
+	resp, err := api.ListWorkersKVsWithOptions(context.Background(), namespaceID, o)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]string, len(resp.Result))
+	for i := 0; i < len(resp.Result); i++ {
+		results[i] = resp.Result[i].Name
+	}
+
+	return results, nil
+}
+
 // Encodes a byte array to a base64 string.
 func encodeToBase64(bytes []byte) string {
 	return base64.StdEncoding.EncodeToString(bytes)

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -53,18 +53,18 @@ func OutputAllMeta(logger *log.Logger, pckgname string) {
 	if pckg, err := GetPackage(ctx, pckgname); err != nil {
 		util.Infof(ctx, "Failed to get package meta: %s\n", err)
 	} else {
-		util.Infof(ctx, "Parsed package: %v\n", pckg)
+		util.Infof(ctx, "Parsed package: %s\n", pckg)
 	}
 
 	// output versions metadata
-	if versions, err := GetVersions(ctx, pckgname); err != nil {
+	if versions, err := GetVersions(pckgname); err != nil {
 		util.Infof(ctx, "Failed to get versions: %s\n", err)
 	} else {
-		for _, v := range versions {
+		for i, v := range versions {
 			if version, err := GetVersion(ctx, v); err != nil {
-				util.Infof(ctx, "Failed to get version: %s\n", err)
+				util.Infof(ctx, "(%d/%d) Failed to get version: %s\n", i+1, len(versions), err)
 			} else {
-				util.Infof(ctx, "Parsed version: %v\n", version)
+				util.Infof(ctx, "(%d/%d) Parsed %s: %v\n", i+1, len(versions), v, version)
 			}
 		}
 	}

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -44,3 +44,13 @@ func InsertMetadataFromDisk(logger *log.Logger, pckgs []string) {
 		util.Check(err)
 	}
 }
+
+// OutputAllMeta is a helper tool to output all metadata associated with a package.
+func OutputAllMeta(logger *log.Logger, pckgname string) {
+	//	ctx := util.ContextWithEntries(util.GetStandardEntries(pckgname, logger)...)
+
+	// output package metadata
+
+	// output versions metadata
+
+}

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"fmt"
 	"log"
 	"path"
 
@@ -64,7 +65,13 @@ func OutputAllMeta(logger *log.Logger, pckgname string) {
 			if version, err := GetVersion(ctx, v); err != nil {
 				util.Infof(ctx, "(%d/%d) Failed to get version: %s\n", i+1, len(versions), err)
 			} else {
-				util.Infof(ctx, "(%d/%d) Parsed %s: %v\n", i+1, len(versions), v, version)
+				var output string
+				if len(version) > 25 {
+					output = fmt.Sprintf("(%d assets)", len(version))
+				} else {
+					output = fmt.Sprintf("%v", version)
+				}
+				util.Infof(ctx, "(%d/%d) Parsed %s: %s\n", i+1, len(versions), v, output)
 			}
 		}
 	}

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -47,10 +47,25 @@ func InsertMetadataFromDisk(logger *log.Logger, pckgs []string) {
 
 // OutputAllMeta is a helper tool to output all metadata associated with a package.
 func OutputAllMeta(logger *log.Logger, pckgname string) {
-	//	ctx := util.ContextWithEntries(util.GetStandardEntries(pckgname, logger)...)
+	ctx := util.ContextWithEntries(util.GetStandardEntries(pckgname, logger)...)
 
 	// output package metadata
+	if pckg, err := GetPackage(ctx, pckgname); err != nil {
+		util.Infof(ctx, "Failed to get package meta: %s\n", err)
+	} else {
+		util.Infof(ctx, "Parsed package: %v\n", pckg)
+	}
 
 	// output versions metadata
-
+	if versions, err := GetVersions(ctx, pckgname); err != nil {
+		util.Infof(ctx, "Failed to get versions: %s\n", err)
+	} else {
+		for _, v := range versions {
+			if version, err := GetVersion(ctx, v); err != nil {
+				util.Infof(ctx, "Failed to get version: %s\n", err)
+			} else {
+				util.Infof(ctx, "Parsed version: %v\n", version)
+			}
+		}
+	}
 }

--- a/kv/versions.go
+++ b/kv/versions.go
@@ -10,9 +10,8 @@ import (
 )
 
 // GetVersions gets the list of KV version keys for a particular package.
-func GetVersions(ctx context.Context, pckgname string) ([]string, error) {
-	var versions []string
-	return versions, nil
+func GetVersions(pckgname string) ([]string, error) {
+	return ListByPrefix(pckgname+"/", versionsNamespaceID)
 }
 
 // GetVersion gets metadata for a particular version.

--- a/kv/versions.go
+++ b/kv/versions.go
@@ -9,6 +9,23 @@ import (
 	"github.com/cdnjs/tools/util"
 )
 
+// GetVersions gets the list of KV version keys for a particular package.
+func GetVersions(ctx context.Context, pckgname string) ([]string, error) {
+	var versions []string
+	return versions, nil
+}
+
+// GetVersion gets metadata for a particular version.
+func GetVersion(ctx context.Context, key string) ([]string, error) {
+	bytes, err := Read(key, versionsNamespaceID)
+	if err != nil {
+		return nil, err
+	}
+	var assets []string
+	err = json.Unmarshal(bytes, &assets)
+	return assets, err
+}
+
 // Gets the request to update a version entry in KV with a number of file assets.
 // Note: for now, a `version` entry is just a []string of assets, but this could become
 // a struct if more metadata is added.


### PR DESCRIPTION
- used for debugging
- will probably evolve into a validator tool eventually

```
tylercaslin@C02ZH7ELLVDQ tools % make kv && ./bin/kv meta a-happy-tyler
go build -mod=readonly -v -ldflags="-s -w" -o bin/kv ./cmd/kv
2020/07/23 14:49:26 a-happy-tyler: Parsed package: &{%!s(*context.valueCtx=&{0xc000021260 1 0xc000108280}) []  a-happy-tyler Tyler is happy. Be like Tyler. %!s(*string=0xc000445790) {a-happy-tyler  %!s(*string=<nil>)}  [tyler happy] {git git://github.com/tc80/a-happy-tyler.git} happy.js [] %!s(*packages.License=&{MIT }) %!s(*packages.Autoupdate=&{git git://github.com/tc80/a-happy-tyler.git <nil>})}
2020/07/23 14:49:27 a-happy-tyler: (1/7) Parsed a-happy-tyler/1.0.10: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js smile.jpg]
2020/07/23 14:49:27 a-happy-tyler: (2/7) Parsed a-happy-tyler/1.0.4: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js]
2020/07/23 14:49:27 a-happy-tyler: (3/7) Parsed a-happy-tyler/1.0.5: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js smile.jpg]
2020/07/23 14:49:28 a-happy-tyler: (4/7) Parsed a-happy-tyler/1.0.6: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js smile.jpg]
2020/07/23 14:49:28 a-happy-tyler: (5/7) Parsed a-happy-tyler/1.0.7: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js smile.jpg]
2020/07/23 14:49:28 a-happy-tyler: (6/7) Parsed a-happy-tyler/1.0.8: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js smile.jpg]
2020/07/23 14:49:28 a-happy-tyler: (7/7) Parsed a-happy-tyler/1.0.9: [happy.css happy.js happy.min.css happy.min.js kristina.js kristina.min.js smile.jpg]
```