### PR TITLE
add new tool to list all unique metadata properties

### DIFF
--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -14,8 +14,6 @@ Output how many package files match and whether they will be ignored for a numbe
 
 Outputs the distribution of packages that contain a particular JSON property (or sub-property).
 
-For example:
-
 ```
 make checker && ./bin/checker meta author email
 ```
@@ -37,3 +35,13 @@ and ones that do not have `author` at all:
 ```
 {}
 ```
+
+## `meta-list`
+
+Lists all the unique JSON keys for this particular JSON object across all packages.
+
+```
+make checker && ./bin/checker meta-list author
+```
+
+This will find the summary of keys found in the `author` JSON object.


### PR DESCRIPTION
Will be used to standardize metadata properties.

For example:

```
make checker && ./bin/checker meta-list author
```

```
Summary of Keys in Object
author: KEYS (1253): name
author: KEYS (678): email
author: KEYS (815): url
author: KEYS (8): twitter
author: [a/alloy-ui.json h/headhesive.json j/jquery.pep.json j/json2csv.json m/mo-js.json p/politespace.json q/quo.js.json t/tracking.js.json]

author: KEYS (21): homepage
author: [a/angular-dialog-service.json b/bootstrap-confirmation.json c/caret.json c/cloudinary-core.json c/cloudinary-jquery-file-upload.json c/cloudinary-jquery.json c/coordinates-picker.json c/css3finalize.json f/fullcalendar-scheduler.json i/iCheck.json i/izimodal.json i/izitoast.json j/jquery-highlighttextarea.json j/jquery-visible.json l/Leaflet.Spin.json m/mistic100-Bootstrap-Confirmation.json q/qwerty-hancock.json s/salvattore.json s/social-feed.json t/task.js.json v/velocity.json]

author: KEYS (1): uri
author: [d/d3.chart.json]

author: KEYS (1): github
author: [p/politespace.json]

author: KEYS (2): company
author: [f/fg-appendaround.json i/infinite-ajax-scroll.json]

author: KEYS (2): homagepage
author: [f/fluidbox.json p/paver.json]

author: KEYS (1): mail
author: [q/quo.js.json]

author: KEYS (47): web
author: KEYS (1): phone
author: [l/localStorage.json]

author: KEYS (1): site
author: [q/quo.js.json]

author: KEYS (2): website
author: [a/across-tabs.json j/jsmpeg.json]
```