### PR TITLE
Delay creating package version directory until needed

### DIFF
--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -133,9 +133,8 @@ func doUpdateGit(ctx context.Context, pckg *packages.Package, gitpath string, ve
 			continue
 		}
 
-		util.Check(os.MkdirAll(pckgpath, os.ModePerm))
-
 		if len(filesToCopy) > 0 {
+			util.Check(os.MkdirAll(pckgpath, os.ModePerm))
 			for _, fileMoveOp := range filesToCopy {
 				absFrom := path.Join(gitpath, fileMoveOp.From)
 				absDest := path.Join(pckgpath, fileMoveOp.To)

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -96,12 +96,11 @@ func doUpdateNpm(ctx context.Context, pckg *packages.Package, versions []npm.Ver
 			continue
 		}
 
-		util.Check(os.MkdirAll(pckgpath, os.ModePerm))
-
 		tarballDir := npm.DownloadTar(ctx, version.Tarball)
 		filesToCopy := pckg.NpmFilesFrom(tarballDir)
 
 		if len(filesToCopy) > 0 {
+			util.Check(os.MkdirAll(pckgpath, os.ModePerm))
 			for _, fileMoveOp := range filesToCopy {
 				absFrom := path.Join(tarballDir, fileMoveOp.From)
 				absDest := path.Join(pckgpath, fileMoveOp.To)


### PR DESCRIPTION
This fix a issue where a empty directory is created, when there is no
files to copy (ex: due to a broken autoupdate config).

Refs: cdnjs/packages#341