### PR TITLE
CI checker will validate path now

### DIFF
--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -1,6 +1,7 @@
 # Checker
 
 Tools for our CI.
+Pass `-any-path` to allow all package file paths to be accepted. Otherwise, the path will be validated against a regex.
 
 ## `lint`
 
@@ -9,4 +10,3 @@ Checks that a package is correctly configured based on its JSON.
 ## `show-files`
 
 Output how many package files match and whether they will be ignored for a number of latest npm/git versions.
-

--- a/cmd/checker/README.md
+++ b/cmd/checker/README.md
@@ -1,7 +1,7 @@
 # Checker
 
 Tools for our CI.
-Pass `-any-path` to allow all package file paths to be accepted. Otherwise, the path will be validated against a regex.
+Pass `-no-path-validation` to allow all package file paths to be accepted. Otherwise, the path will be validated against a regex.
 
 ## `lint`
 

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -26,10 +26,12 @@ var (
 	logger = util.GetCheckerLogger()
 
 	// regex for path in cdnjs/packages/
-	pckgPathRegex = regexp.MustCompile("^/packages/([a-z0-9])/([a-zA-Z0-9._-]+).json$")
+	pckgPathRegex = regexp.MustCompile("^packages/([a-z0-9])/([a-zA-Z0-9._-]+).json$")
 )
 
 func main() {
+	var anyPath bool
+	flag.BoolVar(&anyPath, "any-path", false, "If set, all package paths are accepted.")
 	flag.Parse()
 
 	if util.IsDebug() {
@@ -40,7 +42,7 @@ func main() {
 	case "lint":
 		{
 			for _, path := range flag.Args()[1:] {
-				lintPackage(path)
+				lintPackage(path, anyPath)
 			}
 
 			if errCount > 0 {
@@ -49,7 +51,7 @@ func main() {
 		}
 	case "show-files":
 		{
-			showFiles(flag.Arg(1))
+			showFiles(flag.Arg(1), anyPath)
 
 			if errCount > 0 {
 				os.Exit(1)
@@ -68,12 +70,12 @@ type version interface {
 	Clean(string)                   // Clean a download dir.
 }
 
-func showFiles(pckgPath string) {
+func showFiles(pckgPath string, anyPath bool) {
 	// create context with file path prefix, checker logger
 	ctx := util.ContextWithEntries(util.GetCheckerEntries(pckgPath, logger)...)
 
 	// parse *Package from JSON
-	pckg := parseHumanPackage(ctx, pckgPath)
+	pckg := parseHumanPackage(ctx, pckgPath, anyPath)
 	if pckg == nil {
 		return
 	}
@@ -157,21 +159,23 @@ func showFiles(pckgPath string) {
 
 // Try to parse a *Package, outputting ci errors/warnings.
 // If there is an issue, *Package will be nil.
-func parseHumanPackage(ctx context.Context, pckgPath string) *packages.Package {
-	// check package path matches regex
-	matches := pckgPathRegex.FindStringSubmatch(pckgPath)
-	if matches == nil {
-		err(ctx, fmt.Sprintf("package path `%s` does not match %s", pckgPath, pckgPathRegex.String()))
-		return nil
-	}
+func parseHumanPackage(ctx context.Context, pckgPath string, anyPath bool) *packages.Package {
+	if !anyPath {
+		// check package path matches regex
+		matches := pckgPathRegex.FindStringSubmatch(pckgPath)
+		if matches == nil {
+			err(ctx, fmt.Sprintf("package path `%s` does not match %s", pckgPath, pckgPathRegex.String()))
+			return nil
+		}
 
-	// check the package is going into the correct folder
-	// (ex. My-Package -> packages/m/My-Package.json)
-	actualDir, pckgName := matches[1], matches[2]
-	expectedDir := strings.ToLower(string(pckgName[0]))
-	if actualDir != expectedDir {
-		err(ctx, fmt.Sprintf("package `%s` must go into `%s` dir, not `%s` dir", pckgName, expectedDir, actualDir))
-		return nil
+		// check the package is going into the correct folder
+		// (ex. My-Package -> packages/m/My-Package.json)
+		actualDir, pckgName := matches[1], matches[2]
+		expectedDir := strings.ToLower(string(pckgName[0]))
+		if actualDir != expectedDir {
+			err(ctx, fmt.Sprintf("package `%s` must go into `%s` dir, not `%s` dir", pckgName, expectedDir, actualDir))
+			return nil
+		}
 	}
 
 	// parse package JSON
@@ -283,14 +287,14 @@ func checkFilename(ctx context.Context, pckg *packages.Package) {
 	}
 }
 
-func lintPackage(pckgPath string) {
+func lintPackage(pckgPath string, anyPath bool) {
 	// create context with file path prefix, checker logger
 	ctx := util.ContextWithEntries(util.GetCheckerEntries(pckgPath, logger)...)
 
 	util.Debugf(ctx, "Linting %s...\n", pckgPath)
 
 	// parse *Package from JSON
-	pckg := parseHumanPackage(ctx, pckgPath)
+	pckg := parseHumanPackage(ctx, pckgPath, anyPath)
 	if pckg == nil {
 		return
 	}

--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -30,8 +30,8 @@ var (
 )
 
 func main() {
-	var anyPath bool
-	flag.BoolVar(&anyPath, "any-path", false, "If set, all package paths are accepted.")
+	var noPathValidation bool
+	flag.BoolVar(&noPathValidation, "no-path-validation", false, "If set, all package paths are accepted.")
 	flag.Parse()
 
 	if util.IsDebug() {
@@ -42,7 +42,7 @@ func main() {
 	case "lint":
 		{
 			for _, path := range flag.Args()[1:] {
-				lintPackage(path, anyPath)
+				lintPackage(path, noPathValidation)
 			}
 
 			if errCount > 0 {
@@ -51,7 +51,7 @@ func main() {
 		}
 	case "show-files":
 		{
-			showFiles(flag.Arg(1), anyPath)
+			showFiles(flag.Arg(1), noPathValidation)
 
 			if errCount > 0 {
 				os.Exit(1)
@@ -70,12 +70,12 @@ type version interface {
 	Clean(string)                   // Clean a download dir.
 }
 
-func showFiles(pckgPath string, anyPath bool) {
+func showFiles(pckgPath string, noPathValidation bool) {
 	// create context with file path prefix, checker logger
 	ctx := util.ContextWithEntries(util.GetCheckerEntries(pckgPath, logger)...)
 
 	// parse *Package from JSON
-	pckg := parseHumanPackage(ctx, pckgPath, anyPath)
+	pckg := parseHumanPackage(ctx, pckgPath, noPathValidation)
 	if pckg == nil {
 		return
 	}
@@ -159,8 +159,8 @@ func showFiles(pckgPath string, anyPath bool) {
 
 // Try to parse a *Package, outputting ci errors/warnings.
 // If there is an issue, *Package will be nil.
-func parseHumanPackage(ctx context.Context, pckgPath string, anyPath bool) *packages.Package {
-	if !anyPath {
+func parseHumanPackage(ctx context.Context, pckgPath string, noPathValidation bool) *packages.Package {
+	if !noPathValidation {
 		// check package path matches regex
 		matches := pckgPathRegex.FindStringSubmatch(pckgPath)
 		if matches == nil {
@@ -287,14 +287,14 @@ func checkFilename(ctx context.Context, pckg *packages.Package) {
 	}
 }
 
-func lintPackage(pckgPath string, anyPath bool) {
+func lintPackage(pckgPath string, noPathValidation bool) {
 	// create context with file path prefix, checker logger
 	ctx := util.ContextWithEntries(util.GetCheckerEntries(pckgPath, logger)...)
 
 	util.Debugf(ctx, "Linting %s...\n", pckgPath)
 
 	// parse *Package from JSON
-	pckg := parseHumanPackage(ctx, pckgPath, anyPath)
+	pckg := parseHumanPackage(ctx, pckgPath, noPathValidation)
 	if pckg == nil {
 		return
 	}

--- a/test/checker/checker_test.go
+++ b/test/checker/checker_test.go
@@ -38,8 +38,13 @@ func createFakeBotPath() string {
 }
 
 // start a local proxy server and run the checker binary
-func runChecker(proxy string, args ...string) string {
+func runChecker(proxy string, validatePath bool, args ...string) string {
 	fakeBotPath := createFakeBotPath()
+
+	// used to avoid validating the package's path
+	if !validatePath {
+		args = append([]string{"-no-path-validation"}, args...)
+	}
 
 	cmd := exec.Command("../../bin/checker", args...)
 	cmd.Env = append(os.Environ(),

--- a/test/checker/lint_test.go
+++ b/test/checker/lint_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 type LintTestCase struct {
-	name     string
-	input    string
-	expected []string
+	name         string
+	input        string
+	expected     []string
+	validatePath bool
 }
 
 const (
@@ -60,8 +61,11 @@ func fakeNpmGitHubHandlerLint(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestCheckerLint(t *testing.T) {
-	const httpTestProxy = "localhost:8667"
-	const file = "/tmp/input-lint.json"
+	const (
+		pckgPathRegex = "^packages/([a-z0-9])/([a-zA-Z0-9._-]+).json$"
+		httpTestProxy = "localhost:8667"
+		file          = "/tmp/input-lint.json"
+	)
 
 	cases := []LintTestCase{
 		{
@@ -383,7 +387,7 @@ func TestCheckerLint(t *testing.T) {
 			err := ioutil.WriteFile(file, []byte(tc.input), 0644)
 			assert.Nil(t, err)
 
-			out := runChecker(httpTestProxy, "lint", file)
+			out := runChecker(httpTestProxy, tc.validatePath, "lint", file)
 			assert.Contains(t, tc.expected, out)
 
 			os.Remove(file)

--- a/test/checker/show_files_test.go
+++ b/test/checker/show_files_test.go
@@ -33,6 +33,7 @@ type ShowFilesTestCase struct {
 	input        string
 	expected     string
 	validatePath bool
+	file         *string
 }
 
 func addTarFile(tw *tar.Writer, path string, content string) error {
@@ -468,13 +469,18 @@ most recent version: 2.0.0
 
 		// since all tests share the same input, this needs to run sequentially
 		t.Run(tc.name, func(t *testing.T) {
-			err := ioutil.WriteFile(file, []byte(tc.input), 0644)
-			assert.Nil(t, err)
+			pkgFile := file
+			if tc.file != nil {
+				pkgFile = *tc.file
+			} else {
+				err := ioutil.WriteFile(pkgFile, []byte(tc.input), 0644)
+				assert.Nil(t, err)
+			}
 
-			out := runChecker(httpTestProxy, tc.validatePath, "show-files", file)
+			out := runChecker(httpTestProxy, tc.validatePath, "show-files", pkgFile)
 			assert.Equal(t, tc.expected, "\n"+out)
 
-			os.Remove(file)
+			os.Remove(pkgFile)
 		})
 	}
 

--- a/test/checker/show_files_test.go
+++ b/test/checker/show_files_test.go
@@ -29,9 +29,10 @@ const (
 )
 
 type ShowFilesTestCase struct {
-	name     string
-	input    string
-	expected string
+	name         string
+	input        string
+	expected     string
+	validatePath bool
 }
 
 func addTarFile(tw *tar.Writer, path string, content string) error {
@@ -470,7 +471,7 @@ most recent version: 2.0.0
 			err := ioutil.WriteFile(file, []byte(tc.input), 0644)
 			assert.Nil(t, err)
 
-			out := runChecker(httpTestProxy, "show-files", file)
+			out := runChecker(httpTestProxy, tc.validatePath, "show-files", file)
 			assert.Equal(t, tc.expected, "\n"+out)
 
 			os.Remove(file)


### PR DESCRIPTION
- must match `^packages/([a-z0-9])/([a-zA-Z0-9._-]+).json$`
- then, further checks ensure the package is in the correct directory
- can pass the flag `-no-path-validation` to not validate against this regex (when testing locally)