### PR TITLE
set filename to closest asset if missing in latest version

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -197,24 +197,19 @@ func updateFilenameIfMissing(ctx context.Context, pckg *packages.Package) {
 		panic(fmt.Sprintf("KV version `%s` contains no assets", pckg.LatestVersionKVKey()))
 	}
 
-	var filename string
 	if pckg.Filename != nil {
 		// check if assets contains filename
-		filename = *pckg.Filename
+		filename := *pckg.Filename
 		for _, asset := range assets {
 			if asset == filename {
 				return // filename included in latest version, so return
 			}
 		}
-	} else {
-		// filename does not exist, so we will try to find
-		// the closest asset to the package's name
-		filename = *pckg.Name
-	}
 
-	// set filename to be the most similar string in []assets
-	mostSimilar := getMostSimilarFilename(filename, assets)
-	pckg.Filename = &mostSimilar
+		// set filename to be the most similar string in []assets
+		mostSimilar := getMostSimilarFilename(filename, assets)
+		pckg.Filename = &mostSimilar
+	}
 }
 
 // Gets the most similar filename to a target filename.

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"path"
 	"syscall"
 	"time"
 
+	"github.com/agnivade/levenshtein"
 	"github.com/blang/semver"
 	"github.com/cdnjs/tools/compress"
 	"github.com/cdnjs/tools/kv"
@@ -170,17 +172,63 @@ func main() {
 					}
 
 					pckg.Version = latestVersion
+					updateFilenameIfMissing(ctx, pckg)
 
 					commitPackageVersion(ctx, pckg, f)
 					packages.GitPush(ctx, cdnjsPath)
 
 					if err := kv.UpdateKVPackage(ctx, pckg); err != nil {
-						sentry.NotifyError(fmt.Errorf("failed to write KV package metadata %s: %s", *pckg.Name, err.Error()))
+						panic(fmt.Sprintf("failed to write KV package metadata %s: %s", *pckg.Name, err.Error()))
 					}
 				}
 			}
 		}
 	}
+}
+
+// update the package's filename if the latest
+// version does not contain the filename
+func updateFilenameIfMissing(ctx context.Context, pckg *packages.Package) {
+	// can do this safely since the latest version will be pushed to KV by now
+	assets, err := kv.GetVersion(ctx, pckg.LatestVersionKVKey())
+	util.Check(err)
+
+	if len(assets) == 0 {
+		panic(fmt.Sprintf("KV version `%s` contains no assets", pckg.LatestVersionKVKey()))
+	}
+
+	var filename string
+	if pckg.Filename != nil {
+		// check if assets contains filename
+		filename = *pckg.Filename
+		for _, asset := range assets {
+			if asset == filename {
+				return // filename included in latest version, so return
+			}
+		}
+	} else {
+		// filename does not exist, so we will try to find
+		// the closest asset to the package's name
+		filename = *pckg.Name
+	}
+
+	// set filename to be the most similar string in []assets
+	mostSimilar := getMostSimilarFilename(filename, assets)
+	pckg.Filename = &mostSimilar
+}
+
+// Gets the most similar filename to a target filename.
+// The []string of alternatives must have at least one element.
+func getMostSimilarFilename(target string, filenames []string) string {
+	var mostSimilar string
+	var minDist int = math.MaxInt32
+	for _, f := range filenames {
+		if dist := levenshtein.ComputeDistance(target, f); dist < minDist {
+			mostSimilar = f
+			minDist = dist
+		}
+	}
+	return mostSimilar
 }
 
 // Gets the latest stable version by time stamp. A  "stable" version is
@@ -261,7 +309,7 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 
 		util.Debugf(ctx, "writing version to KV %s", path.Join(pkg, version))
 		if err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath); err != nil {
-			sentry.NotifyError(fmt.Errorf("failed to write kv version %s: %s", path.Join(pkg, version), err.Error()))
+			panic(fmt.Sprintf("failed to write kv version %s: %s", path.Join(pkg, version), err.Error()))
 		}
 	}
 }

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -186,8 +186,9 @@ func main() {
 	}
 }
 
-// update the package's filename if the latest
+// Update the package's filename if the latest
 // version does not contain the filename
+// Note that if the filename is nil it will stay nil.
 func updateFilenameIfMissing(ctx context.Context, pckg *packages.Package) {
 	// can do this safely since the latest version will be pushed to KV by now
 	assets, err := kv.GetVersion(ctx, pckg.LatestVersionKVKey())

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	cloud.google.com/go v0.53.0 // indirect
 	cloud.google.com/go/storage v1.5.0
+	github.com/agnivade/levenshtein v1.1.0
 	github.com/algolia/algoliasearch-client-go/v3 v3.4.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudflare/cloudflare-go v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -30,9 +30,13 @@ github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mo
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
+github.com/agnivade/levenshtein v1.1.0 h1:n6qGwyHG61v3ABce1rPVZklEYRT8NFpCMrpZdBUbYGM=
+github.com/agnivade/levenshtein v1.1.0/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/algolia/algoliasearch-client-go/v3 v3.4.0 h1:eeVU30L5DkKUK2q/EjXw+8o7reoK4QB1mS+BG0Jbd4Y=
 github.com/algolia/algoliasearch-client-go/v3 v3.4.0/go.mod h1:d0/D54BCmkwhLxT5VIQBeYLAz2GbZHFX9OptYyohTr0=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
+github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
@@ -56,6 +60,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
+github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -49,7 +49,6 @@ func OutputAllFiles(logger *log.Logger, pckgName string) {
 			}
 		}
 	}
-
 }
 
 // OutputAllMeta outputs all metadata associated with a package.

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -88,6 +88,11 @@ func (p *Package) Marshal() ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+// LatestVersionKVKey gets the key needed to get the latest KV version metadata.
+func (p *Package) LatestVersionKVKey() string {
+	return path.Join(*p.Name, *p.Version)
+}
+
 // LibraryPath returns the location of the package in the cdnjs repo.
 func (p *Package) LibraryPath() string {
 	return path.Join(util.GetCDNJSLibrariesPath(), *p.Name)


### PR DESCRIPTION
- if `filename` does not exist, leave it missing
- if `filename` exists and doesn't exist in assets, set to the closest asset
- if `len(assets) == 0`, `panic`

Note that "closest" refers to the asset string with a minimum Levenshtein distance from the `filename`/package name.