### PR TITLE
Remove npm/git misconfigured check

### DIFF
--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -82,7 +82,7 @@ func updateGit(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	} else {
 		if len(existingVersionSet) > 0 {
 			// all existing versions are not on git anymore
-			util.Debugf(ctx, "all existing versions not on git: %s", *pckg.Name)
+			util.Debugf(ctx, "all existing versions not on git: %s\n", *pckg.Name)
 		}
 		// Import all the versions since we have none locally.
 		// Limit the number of version to an arbitrary number to avoid publishing

--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -82,24 +82,22 @@ func updateGit(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	} else {
 		if len(existingVersionSet) > 0 {
 			// all existing versions are not on git anymore
-			// so we will ignore this package
-			util.Debugf(ctx, "ignoring misconfigured git package: %s", pckg.Name)
-		} else {
-			// Import all the versions since we have none locally.
-			// Limit the number of version to an abrirary number to avoid publishing
-			// too many outdated versions.
-			sort.Sort(sort.Reverse(git.ByTimeStamp(gitVersions)))
-
-			if len(gitVersions) > util.ImportAllMaxVersions {
-				gitVersions = gitVersions[len(gitVersions)-util.ImportAllMaxVersions:]
-			}
-
-			// Reverse the array to have the older versions first
-			// It matters when we will commit the updates
-			sort.Sort(sort.Reverse(git.ByTimeStamp(gitVersions)))
-
-			newVersionsToCommit = doUpdateGit(ctx, pckg, packageGitcache, gitVersions)
+			util.Debugf(ctx, "all existing versions not on git: %s", *pckg.Name)
 		}
+		// Import all the versions since we have none locally.
+		// Limit the number of version to an arbitrary number to avoid publishing
+		// too many outdated versions.
+		sort.Sort(sort.Reverse(git.ByTimeStamp(gitVersions)))
+
+		if len(gitVersions) > util.ImportAllMaxVersions {
+			gitVersions = gitVersions[len(gitVersions)-util.ImportAllMaxVersions:]
+		}
+
+		// Reverse the array to have the older versions first
+		// It matters when we will commit the updates
+		sort.Sort(sort.Reverse(git.ByTimeStamp(gitVersions)))
+
+		newVersionsToCommit = doUpdateGit(ctx, pckg, packageGitcache, gitVersions)
 	}
 
 	// add all new versions to list of all versions

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -48,7 +48,7 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	} else {
 		if len(existingVersionSet) > 0 {
 			// all existing versions are not on npm anymore
-			util.Debugf(ctx, "all existing versions not on npm: %s", pckg.Name)
+			util.Debugf(ctx, "all existing versions not on npm: %s\n", *pckg.Name)
 		}
 		// Import all the versions since we have no current npm versions locally.
 		// Limit the number of version to an arbitrary number to avoid publishing

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -48,24 +48,22 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	} else {
 		if len(existingVersionSet) > 0 {
 			// all existing versions are not on npm anymore
-			// so we will ignore this package
-			util.Debugf(ctx, "ignoring misconfigured npm package: %s", pckg.Name)
-		} else {
-			// Import all the versions since we have none locally.
-			// Limit the number of version to an abrirary number to avoid publishing
-			// too many outdated versions.
-			sort.Sort(sort.Reverse(npm.ByTimeStamp(npmVersions)))
-
-			if len(npmVersions) > util.ImportAllMaxVersions {
-				npmVersions = npmVersions[len(npmVersions)-util.ImportAllMaxVersions:]
-			}
-
-			// Reverse the array to have the older versions first
-			// It matters when we will commit the updates
-			sort.Sort(sort.Reverse(npm.ByTimeStamp(npmVersions)))
-
-			newVersionsToCommit = doUpdateNpm(ctx, pckg, npmVersions)
+			util.Debugf(ctx, "all existing versions not on npm: %s", pckg.Name)
 		}
+		// Import all the versions since we have no current npm versions locally.
+		// Limit the number of version to an arbitrary number to avoid publishing
+		// too many outdated versions.
+		sort.Sort(sort.Reverse(npm.ByTimeStamp(npmVersions)))
+
+		if len(npmVersions) > util.ImportAllMaxVersions {
+			npmVersions = npmVersions[len(npmVersions)-util.ImportAllMaxVersions:]
+		}
+
+		// Reverse the array to have the older versions first
+		// It matters when we will commit the updates
+		sort.Sort(sort.Reverse(npm.ByTimeStamp(npmVersions)))
+
+		newVersionsToCommit = doUpdateNpm(ctx, pckg, npmVersions)
 	}
 
 	// add all new versions to list of all versions


### PR DESCRIPTION
- Will fix the [packages that can't update](https://github.com/cdnjs/packages/issues/341)

Currently, if a package consists of only outdated versions (not on git or npm), it will be ignored and no more versions will be pulled. This PR will remove this check.