### PR TITLE
woff will now be compressed

### DIFF
--- a/kv/files.go
+++ b/kv/files.go
@@ -21,9 +21,8 @@ var (
 		".gz": true,
 	}
 	// these file extensions will be uploaded to KV
-	// but not compessed
+	// but not compressed
 	doNotCompress = map[string]bool{
-		".woff":  true,
 		".woff2": true,
 	}
 )


### PR DESCRIPTION
- To ensure all `woff` files are compressed, when we do our big migration we should clear the prod namespace and re-upload all packages in KV