### PR TITLE
avoid interrupting git pulls

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -74,15 +74,15 @@ func main() {
 		fmt.Printf("Running in debug mode (no-update=%t, no-pull=%t)\n", noUpdate, noPull)
 	}
 
+	// create channel to handle signals
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM)
+
 	if !noPull {
 		util.UpdateGitRepo(defaultCtx, cdnjsPath)
 		util.UpdateGitRepo(defaultCtx, packagesPath)
 		util.UpdateGitRepo(defaultCtx, logsPath)
 	}
-
-	// create channel to handle signals
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGTERM)
 
 	for _, f := range packages.GetHumanPackageJSONFiles(defaultCtx) {
 		// create context with file path prefix, standard debug logger


### PR DESCRIPTION
- if a git pull is interrupted, it might create a git lock file that can interfere with the next time the autoupdate service is run