### PR TITLE
Push aggregated metadata to KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repository contains various tools that we use to help with the process of m
 - `WORKERS_KV_FILES_NAMESPACE_ID` workers kv namespace ID for files
 - `WORKERS_KV_VERSIONS_NAMESPACE_ID` workers kv namespace ID containing metadata for versions
 - `WORKERS_KV_PACKAGES_NAMESPACE_ID` workers kv namespace ID containing metadata for packages
+- `WORKERS_KV_AGGREGATED_METADATA_NAMESPACE_ID` workers kv namespace ID containing aggregated metadata for packages
 - `WORKERS_KV_ACCOUNT_ID` workers kv account ID
 - `WORKERS_KV_API_TOKEN` workers kv api token
 

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -144,11 +144,8 @@ func main() {
 			// Update package metadata.
 			updatePackage(ctx, pckg, allVersions, f)
 
-			_ = newAssets
-			// TODO: Uncomment this when all aggregated metadata entries are in KV.
-			//
 			// Update aggregated package metadata for cdnjs API.
-			// updateAggregatedMetadata(ctx, pckg, newAssets)
+			updateAggregatedMetadata(ctx, pckg, newAssets)
 		}
 	}
 }
@@ -246,10 +243,8 @@ func updateFilenameIfMissing(ctx context.Context, pckg *packages.Package) {
 	key := pckg.LatestVersionKVKey()
 	assets, err := kv.GetVersion(ctx, key)
 	if err != nil {
-		// TODO: Change to panic, since once all packages are uploaded to KV
-		// all package metadata will be in KV, so this error should never occur.
-		util.Debugf(ctx, "KV metadata not found for latest version `%s`", key)
-		return
+		// All package metadata will be in KV, so this error should never occur.
+		panic(fmt.Sprintf("KV metadata not found for latest version `%s`", key))
 	}
 
 	if len(assets) == 0 {

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -64,8 +64,7 @@ func (n newVersionToCommit) GetTimeStamp() time.Time {
 func main() {
 	defer sentry.PanicHandler()
 
-	var noUpdate bool
-	var noPull bool
+	var noUpdate, noPull bool
 	flag.BoolVar(&noUpdate, "no-update", false, "if set, the autoupdater will not commit or push to git")
 	flag.BoolVar(&noPull, "no-pull", false, "if set, the autoupdater will not pull from git")
 	flag.Parse()
@@ -144,8 +143,11 @@ func main() {
 			// Update package metadata.
 			updatePackage(ctx, pckg, allVersions, f)
 
-			// Update aggregated package metadata for cdnjs API.
-			updateAggregatedMetadata(ctx, pckg, newAssets)
+			// For now, only update aggregate metadata for test package.
+			if *pckg.Name == "a-happy-tyler" {
+				// Update aggregated package metadata for cdnjs API.
+				updateAggregatedMetadata(ctx, pckg, newAssets)
+			}
 		}
 	}
 }

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -14,16 +14,18 @@ make kv && ./bin/kv upload jquery mathjax fontawesome
 ## `upload-aggregate`
 
 Inserts aggregate metadata to KV from scratch by scraping KV entries for package-level and version-specific metadata.
-Note that currently if there are more than 1000 versions for a package, it will only process the first 1000.
 
 ```
 make kv && ./bin/kv upload-aggregate jquery mathjax fontawesome
 ```
 
+## `packages`
+
+Lists all packages in KV.
+
 ## `files`
 
 Gets the file names stored in KV for a package.
-Note that currently if there are more than 1000 files, it will only note that 1000 exist.
 
 ```
 make kv && ./bin/kv files jquery
@@ -32,7 +34,6 @@ make kv && ./bin/kv files jquery
 ## `meta`
 
 Gets all metadata associated with a package in KV.
-Note that currently if there are more than 1000 versions for a package, it will only process the first 1000.
 
 ```
 make kv && ./bin/kv meta jquery

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -14,6 +14,7 @@ make kv && ./bin/kv upload jquery mathjax fontawesome
 ## `upload-aggregate`
 
 Inserts aggregate metadata to KV from scratch by scraping KV entries for package-level and version-specific metadata.
+Note that currently if there are more than 1000 versions for a package, it will only process the first 1000.
 
 ```
 make kv && ./bin/kv upload-aggregate jquery mathjax fontawesome
@@ -35,4 +36,12 @@ Note that currently if there are more than 1000 versions for a package, it will 
 
 ```
 make kv && ./bin/kv meta jquery
+```
+
+## `aggregate`
+
+Gets the aggregated metadata associated with a package in KV.
+
+```
+make kv && ./bin/kv aggregate jquery
 ```

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -11,6 +11,14 @@ If the flag `-meta-only` is set, only version metadata will be pushed to KV.
 make kv && ./bin/kv upload jquery mathjax fontawesome
 ```
 
+## `upload-aggregate`
+
+Inserts aggregate metadata to KV from scratch by scraping KV entries for package-level and version-specific metadata.
+
+```
+make kv && ./bin/kv upload-aggregate jquery mathjax fontawesome
+```
+
 ## `files`
 
 Gets the file names stored in KV for a package.

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -23,6 +23,14 @@ make kv && ./bin/kv upload-aggregate jquery mathjax fontawesome
 
 Lists all packages in KV.
 
+## `aggregate-packages`
+
+Lists all packages with aggregated metadata in KV. To check each package in KV has an entry for aggregated metadata:
+
+```
+unset DEBUG && make kv && diff <(./bin/kv aggregated-packages) <(./bin/kv packages)
+```
+
 ## `files`
 
 Gets the file names stored in KV for a package.

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -39,6 +39,15 @@ func main() {
 
 			kv.InsertFromDisk(logger, pckgs, metaOnly)
 		}
+	case "upload-aggregate":
+		{
+			pckgs := flag.Args()[1:]
+			if len(pckgs) == 0 {
+				panic("no packages specified")
+			}
+
+			kv.InsertFromDisk(logger, pckgs, metaOnly)
+		}
 	case "files":
 		{
 			pckg := flag.Arg(1)

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -48,6 +48,10 @@ func main() {
 
 			kv.InsertAggregateMetadataFromScratch(logger, pckgs)
 		}
+	case "packages":
+		{
+			kv.OutputAllPackages()
+		}
 	case "files":
 		{
 			pckg := flag.Arg(1)
@@ -73,7 +77,7 @@ func main() {
 				panic("no package specified")
 			}
 
-			kv.OutputAggregate(logger, pckg)
+			kv.OutputAggregate(pckg)
 		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -46,7 +46,7 @@ func main() {
 				panic("no packages specified")
 			}
 
-			kv.InsertFromDisk(logger, pckgs, metaOnly)
+			kv.InsertAggregateMetadataFromScratch(logger, pckgs)
 		}
 	case "files":
 		{
@@ -65,6 +65,15 @@ func main() {
 			}
 
 			kv.OutputAllMeta(logger, pckg)
+		}
+	case "aggregate":
+		{
+			pckg := flag.Arg(1)
+			if pckg == "" {
+				panic("no package specified")
+			}
+
+			kv.OutputAggregate(logger, pckg)
 		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -48,6 +48,10 @@ func main() {
 
 			kv.InsertAggregateMetadataFromScratch(logger, pckgs)
 		}
+	case "aggregate-packages":
+		{
+			kv.OutputAllAggregatePackages()
+		}
 	case "packages":
 		{
 			kv.OutputAllPackages()

--- a/compress/algorithm.go
+++ b/compress/algorithm.go
@@ -50,3 +50,17 @@ func Gzip9Native(uncompressed []byte) []byte {
 
 	return b.Bytes()
 }
+
+// UnGzip uncompresses a gzip file as bytes.
+func UnGzip(compressed []byte) []byte {
+	b := bytes.NewBuffer(compressed)
+
+	r, err := gzip.NewReader(b)
+	util.Check(err)
+
+	var res bytes.Buffer
+	_, err = res.ReadFrom(r)
+	util.Check(err)
+
+	return res.Bytes()
+}

--- a/kv/aggregate.go
+++ b/kv/aggregate.go
@@ -1,0 +1,70 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cdnjs/tools/compress"
+	"github.com/cdnjs/tools/util"
+
+	"github.com/cdnjs/tools/packages"
+)
+
+// UpdateAggregatedMetadata updates a package's KV entry for aggregated metadata.
+func UpdateAggregatedMetadata(ctx context.Context, pckg *packages.Package, newAssets []packages.Asset) ([]string, error) {
+	aggPckg, err := getAggregatedMetadata(*pckg.Name)
+	if err != nil {
+		switch err.(type) {
+		case KeyNotFoundError:
+			{
+				// key not found (new package)
+				util.Debugf(ctx, "KV key `%s` not found, inserting aggregated metadata...\n", *pckg.Name)
+				pckg.Assets = newAssets
+			}
+		default:
+			{
+				return nil, err
+			}
+		}
+	} else {
+		util.Debugf(ctx, "Aggregated metadata for `%s` found. Inserting aggregated metadata...\n", *pckg.Name)
+		pckg.Assets = append(aggPckg.Assets, newAssets...)
+	}
+
+	return writeAggregatedMetadata(ctx, pckg)
+}
+
+// Reads an aggregated metadata entry in KV, ungzipping it and
+// unmarshalling it into a *packages.Package.
+func getAggregatedMetadata(key string) (*packages.Package, error) {
+	gzipBytes, err := Read(key, aggregatedMetadataNamespaceID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal and ungzip
+	var p packages.Package
+	util.Check(json.Unmarshal(compress.UnGzip(gzipBytes), &p))
+
+	return &p, nil
+}
+
+// Writes an aggregated metadata entry to KV, gzipping the bytes.
+func writeAggregatedMetadata(ctx context.Context, p *packages.Package) ([]string, error) {
+	// marshal package into JSON
+	v, err := p.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal KV package JSON: %s", *p.Name)
+	}
+
+	// gzip the bytes
+	req := &writeRequest{
+		key:   *p.Name,
+		value: compress.Gzip9Native(v),
+	}
+
+	// write aggregated to KV
+	return encodeAndWriteKVBulk(ctx, []*writeRequest{req}, aggregatedMetadataNamespaceID)
+}

--- a/kv/aggregate.go
+++ b/kv/aggregate.go
@@ -28,7 +28,7 @@ func UpdateAggregatedMetadata(ctx context.Context, pckg *packages.Package, newAs
 			}
 		}
 	} else {
-		util.Debugf(ctx, "Aggregated metadata for `%s` found. Inserting aggregated metadata...\n", *pckg.Name)
+		util.Debugf(ctx, "Aggregated metadata for `%s` found. Updating aggregated metadata...\n", *pckg.Name)
 		pckg.Assets = append(aggPckg.Assets, newAssets...)
 	}
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -20,12 +20,13 @@ const (
 )
 
 var (
-	filesNamespaceID    = util.GetEnv("WORKERS_KV_FILES_NAMESPACE_ID")
-	versionsNamespaceID = util.GetEnv("WORKERS_KV_VERSIONS_NAMESPACE_ID")
-	packagesNamespaceID = util.GetEnv("WORKERS_KV_PACKAGES_NAMESPACE_ID")
-	accountID           = util.GetEnv("WORKERS_KV_ACCOUNT_ID")
-	apiToken            = util.GetEnv("WORKERS_KV_API_TOKEN")
-	api                 = getAPI()
+	filesNamespaceID              = util.GetEnv("WORKERS_KV_FILES_NAMESPACE_ID")
+	versionsNamespaceID           = util.GetEnv("WORKERS_KV_VERSIONS_NAMESPACE_ID")
+	packagesNamespaceID           = util.GetEnv("WORKERS_KV_PACKAGES_NAMESPACE_ID")
+	aggregatedMetadataNamespaceID = util.GetEnv("WORKERS_KV_AGGREGATED_METADATA_NAMESPACE_ID")
+	accountID                     = util.GetEnv("WORKERS_KV_ACCOUNT_ID")
+	apiToken                      = util.GetEnv("WORKERS_KV_API_TOKEN")
+	api                           = getAPI()
 )
 
 // KeyNotFoundError represents a KV key not found.

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -75,6 +75,17 @@ func InsertAggregateMetadataFromScratch(logger *log.Logger, pckgs []string) {
 	}
 }
 
+// OutputAllPackages outputs all files stored in KV for a particular package.
+func OutputAllPackages() {
+	res, err := ListByPrefix("", packagesNamespaceID)
+	util.Check(err)
+
+	bytes, err := json.Marshal(res)
+	util.Check(err)
+
+	fmt.Printf("%s\n", bytes)
+}
+
 // OutputAllFiles outputs all files stored in KV for a particular package.
 func OutputAllFiles(logger *log.Logger, pckgName string) {
 	ctx := util.ContextWithEntries(util.GetStandardEntries(pckgName, logger)...)
@@ -131,7 +142,7 @@ func OutputAllMeta(logger *log.Logger, pckgName string) {
 }
 
 // OutputAggregate outputs the aggregated metadata associated with a package.
-func OutputAggregate(logger *log.Logger, pckgName string) {
+func OutputAggregate(pckgName string) {
 	bytes, err := Read(pckgName, aggregatedMetadataNamespaceID)
 	util.Check(err)
 

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/cdnjs/tools/compress"
+
 	"github.com/cdnjs/tools/packages"
 	"github.com/cdnjs/tools/sentry"
 	"github.com/cdnjs/tools/util"
@@ -125,4 +127,12 @@ func OutputAllMeta(logger *log.Logger, pckgName string) {
 			}
 		}
 	}
+}
+
+// OutputAggregate outputs the aggregated metadata associated with a package.
+func OutputAggregate(logger *log.Logger, pckgName string) {
+	bytes, err := Read(pckgName, aggregatedMetadataNamespaceID)
+	util.Check(err)
+
+	fmt.Printf("%s\n", compress.UnGzip(bytes))
 }

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -27,7 +27,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly bool) {
 		for j, version := range versions {
 			util.Infof(ctx, "p(%d/%d) v(%d/%d) Inserting %s (%s)\n", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version)
 			dir := path.Join(basePath, *pckg.Name, version)
-			_, _, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly)
+			_, _, _, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly)
 			util.Check(err)
 		}
 	}

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -100,7 +100,18 @@ func InsertAggregateMetadataFromScratch(logger *log.Logger, pckgs []string) {
 	log.Println("Done.")
 }
 
-// OutputAllPackages outputs all files stored in KV for a particular package.
+// OutputAllAggregatePackages outputs all the names of all aggregated package metadata entries in KV.
+func OutputAllAggregatePackages() {
+	res, err := ListByPrefix("", aggregatedMetadataNamespaceID)
+	util.Check(err)
+
+	bytes, err := json.Marshal(res)
+	util.Check(err)
+
+	fmt.Printf("%s\n", bytes)
+}
+
+// OutputAllPackages outputs the names of all packages in KV.
 func OutputAllPackages() {
 	res, err := ListByPrefix("", packagesNamespaceID)
 	util.Check(err)

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"path"
@@ -134,5 +135,11 @@ func OutputAggregate(logger *log.Logger, pckgName string) {
 	bytes, err := Read(pckgName, aggregatedMetadataNamespaceID)
 	util.Check(err)
 
-	fmt.Printf("%s\n", compress.UnGzip(bytes))
+	uncompressed := compress.UnGzip(bytes)
+
+	// check if it can unmarshal into a package successfully
+	var p packages.Package
+	util.Check(json.Unmarshal(uncompressed, &p))
+
+	fmt.Printf("%s\n", uncompressed)
 }

--- a/kv/versions.go
+++ b/kv/versions.go
@@ -28,14 +28,14 @@ func GetVersion(ctx context.Context, key string) ([]string, error) {
 // Gets the request to update a version entry in KV with a number of file assets.
 // Note: for now, a `version` entry is just a []string of assets, but this could become
 // a struct if more metadata is added.
-func updateVersionRequest(pkg, version string, fromVersionPaths []string) *writeRequest {
+func updateVersionRequest(pkg, version string, fromVersionPaths []string) ([]string, *writeRequest) {
 	key := path.Join(pkg, version)
 
 	sort.Strings(fromVersionPaths)
 	v, err := json.Marshal(fromVersionPaths)
 	util.Check(err)
 
-	return &writeRequest{
+	return fromVersionPaths, &writeRequest{
 		key:   key,
 		value: v,
 	}
@@ -43,8 +43,8 @@ func updateVersionRequest(pkg, version string, fromVersionPaths []string) *write
 
 // Updates KV with new version's metadata.
 // The []string of `fromVersionPaths` will already contain the optimized/minified files by now.
-func updateKVVersion(ctx context.Context, pkg, version string, fromVersionPaths []string) ([]byte, error) {
-	req := updateVersionRequest(pkg, version, fromVersionPaths)
+func updateKVVersion(ctx context.Context, pkg, version string, fromVersionPaths []string) ([]string, []byte, error) {
+	fromVersionPaths, req := updateVersionRequest(pkg, version, fromVersionPaths)
 	_, err := encodeAndWriteKVBulk(ctx, []*writeRequest{req}, versionsNamespaceID)
-	return req.value, err
+	return fromVersionPaths, req.value, err
 }

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -68,7 +68,8 @@ type Package struct {
 
 	// legacy
 	Author *string `json:"author,omitempty"`
-	// TODO: Remove this when we remove package.min.js generation
+
+	// for aggregated metadata entries
 	Assets []Asset `json:"assets,omitempty"`
 }
 


### PR DESCRIPTION
fixes #174 #175 

- bot will update aggregated metadata

- made a new tool to upload aggregated metadata concurrently
- made a new tool to view aggregated metadata (ungzip and print)

- new namespace (WORKERS_KV_AGGREGATED_METADATA_NAMESPACE_ID)

Note: I set the bot to only update aggregated metadata for `a-happy-tyler` so I can test it is working properly. If it works properly, I will shutdown the bot and upload all aggregated metadata concurrently 👍 