### PR TITLE
Purge cache by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ This repository contains various tools that we use to help with the process of m
 - `WORKERS_KV_VERSIONS_NAMESPACE_ID` workers kv namespace ID containing metadata for versions
 - `WORKERS_KV_PACKAGES_NAMESPACE_ID` workers kv namespace ID containing metadata for packages
 - `WORKERS_KV_AGGREGATED_METADATA_NAMESPACE_ID` workers kv namespace ID containing aggregated metadata for packages
-- `WORKERS_KV_ACCOUNT_ID` workers kv account ID
-- `WORKERS_KV_API_TOKEN` workers kv api token
+- `CF_ACCOUNT_ID` cloudflare kv account ID
+- `CF_ZONE_ID` cloudflare kv zone ID
+- `CF_API_TOKEN` cloudflare api token
 
 ## Dependencies
 

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -54,3 +54,25 @@ Gets the aggregated metadata associated with a package in KV.
 ```
 make kv && ./bin/kv aggregate jquery
 ```
+
+## `purge`
+
+Purges cache by [tag](https://developers.cloudflare.com/workers/reference/apis/cache/).
+
+To purge cache for a new package:
+
+```
+make kv && ./bin/kv purge /packages
+```
+
+To purge cache for package-level metadata, list of versions, and aggregated metadata:
+
+```
+make kv && ./bin/kv purge a-happy-tyler
+```
+
+To purge cache of a specific version:
+
+```
+./bin/kv purge a-happy-tyler/versions/1.0.0
+```

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -74,5 +74,5 @@ make kv && ./bin/kv purge a-happy-tyler
 To purge cache of a specific version:
 
 ```
-./bin/kv purge a-happy-tyler/versions/1.0.0
+./bin/kv purge a-happy-tyler/1.0.0
 ```

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -83,6 +83,16 @@ func main() {
 
 			kv.OutputAggregate(pckg)
 		}
+	case "purge":
+		{
+			tag := flag.Arg(1)
+			if tag == "" {
+				panic("no tag specified")
+			}
+
+			util.Check(kv.PurgeTags([]string{tag}))
+			fmt.Printf("Purged `%s`.\n", tag)
+		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))
 	}

--- a/kv/cache.go
+++ b/kv/cache.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"fmt"
 
-	"github.com/cdnjs/tools/util"
 	"github.com/cloudflare/cloudflare-go"
 )
 
@@ -12,7 +11,11 @@ func PurgeTags(tags []string) error {
 	resp, err := api.PurgeCache(zoneID, cloudflare.PurgeCacheRequest{
 		Tags: tags,
 	})
-	util.Check(err)
-	fmt.Println(resp)
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf(fmt.Sprintf("purge tags fail: %v", resp))
+	}
 	return nil
 }

--- a/kv/cache.go
+++ b/kv/cache.go
@@ -1,0 +1,18 @@
+package kv
+
+import (
+	"fmt"
+
+	"github.com/cdnjs/tools/util"
+	"github.com/cloudflare/cloudflare-go"
+)
+
+// PurgeTags purges the zone's cache by tags.
+func PurgeTags(tags []string) error {
+	resp, err := api.PurgeCache(zoneID, cloudflare.PurgeCacheRequest{
+		Tags: tags,
+	})
+	util.Check(err)
+	fmt.Println(resp)
+	return nil
+}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -24,8 +24,9 @@ var (
 	versionsNamespaceID           = util.GetEnv("WORKERS_KV_VERSIONS_NAMESPACE_ID")
 	packagesNamespaceID           = util.GetEnv("WORKERS_KV_PACKAGES_NAMESPACE_ID")
 	aggregatedMetadataNamespaceID = util.GetEnv("WORKERS_KV_AGGREGATED_METADATA_NAMESPACE_ID")
-	accountID                     = util.GetEnv("WORKERS_KV_ACCOUNT_ID")
-	apiToken                      = util.GetEnv("WORKERS_KV_API_TOKEN")
+	accountID                     = util.GetEnv("CF_ACCOUNT_ID")
+	zoneID                        = util.GetEnv("CF_ZONE_ID")
+	apiToken                      = util.GetEnv("CF_API_TOKEN")
 	api                           = getAPI()
 )
 


### PR DESCRIPTION
Addresses #178 .

The bot will purge our CF zone's cache using tags.
- If a new package is found, purge `/packages` tag (contains list of all pkgs).
- If new versions were added or a package's metadata was updated, purge `<pkg name>` tag (package-level metadata, list of versions, aggregated metadata)

We need to be careful of race conditions.
- If cache is purged but KV values are not yet propagated globally, it is possible the Worker will fetch stale entries from KV and cache them.
- Maybe we can set Worker's `max-age` to a day instead of a year (if we implement this)

If we do this change, we will need to update `bot-ansible`:
- `WORKERS_KV_ACCOUNT_ID` --> `CF_ACCOUNT_ID`
- `WORKERS_KV_API_TOKEN` --> `CF_API_TOKEN`
- need to add `CF_ZONE_ID`
- need to update privileges of `CF_API_TOKEN` to be able to purge zone's cache
