### PR TITLE
Push SRIs to new KV namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This repository contains various tools that we use to help with the process of m
 - `BOT_BASE_PATH`: cdnjs home
 - `SENTRY_DSN` sentry data source name (DSN)
 - `WORKERS_KV_FILES_NAMESPACE_ID` workers kv namespace ID for files
+- `WORKERS_KV_SRIS_NAMESPACE_ID` workers kv namespace ID for file SRIs
 - `WORKERS_KV_VERSIONS_NAMESPACE_ID` workers kv namespace ID containing metadata for versions
 - `WORKERS_KV_PACKAGES_NAMESPACE_ID` workers kv namespace ID containing metadata for packages
 - `WORKERS_KV_AGGREGATED_METADATA_NAMESPACE_ID` workers kv namespace ID containing aggregated metadata for packages

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -396,8 +396,8 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 
 		// Git add/commit new version to cdnjs/logs
 		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version: %s: %s", newVersionToCommit.newVersion, kvVersionMetadata))
-		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version kv: %s: %s", newVersionToCommit.newVersion, kvCompressedFilesJSON))
-		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version SRIs kv: %s: %s", newVersionToCommit.newVersion, kvSRIsJSON))
+		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version kv files: %s: %s", newVersionToCommit.newVersion, kvCompressedFilesJSON))
+		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version kv SRIs: %s: %s", newVersionToCommit.newVersion, kvSRIsJSON))
 		logsCommitMsg := fmt.Sprintf("Add %s (%s)", *newVersionToCommit.pckg.Name, newVersionToCommit.newVersion)
 		packages.GitCommit(ctx, logsPath, logsCommitMsg)
 

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -383,7 +383,7 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 		pkg, version := *newVersionToCommit.pckg.Name, newVersionToCommit.newVersion
 
 		util.Debugf(ctx, "writing version to KV %s", path.Join(pkg, version))
-		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false)
+		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false, false)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write kv version %s: %s", path.Join(pkg, version), err.Error()))
 		}

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -383,7 +383,7 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 		pkg, version := *newVersionToCommit.pckg.Name, newVersionToCommit.newVersion
 
 		util.Debugf(ctx, "writing version to KV %s", path.Join(pkg, version))
-		kvVersionFiles, kvVersionMetadata, kvCompressedFiles, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false)
+		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write kv version %s: %s", path.Join(pkg, version), err.Error()))
 		}
@@ -391,9 +391,13 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 		kvCompressedFilesJSON, err := json.Marshal(kvCompressedFiles)
 		util.Check(err)
 
+		kvSRIsJSON, err := json.Marshal(kvSRIs)
+		util.Check(err)
+
 		// Git add/commit new version to cdnjs/logs
 		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version: %s: %s", newVersionToCommit.newVersion, kvVersionMetadata))
 		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version kv: %s: %s", newVersionToCommit.newVersion, kvCompressedFilesJSON))
+		packages.GitAdd(ctx, logsPath, newVersionToCommit.pckg.Log("new version SRIs kv: %s: %s", newVersionToCommit.newVersion, kvSRIsJSON))
 		logsCommitMsg := fmt.Sprintf("Add %s (%s)", *newVersionToCommit.pckg.Name, newVersionToCommit.newVersion)
 		packages.GitCommit(ctx, logsPath, logsCommitMsg)
 

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -6,6 +6,8 @@ Tools to test our Workers KV namespace.
 
 Inserts packages from disk to KV. Package files and version metadata will be pushed to KV.
 If the flag `-meta-only` is set, only version metadata will be pushed to KV.
+If the flag `-sris-only` is set, only SRIs are pushed to KV.
+These two flags are mutually exclusive.
 
 ```
 make kv && ./bin/kv upload jquery mathjax fontawesome

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -54,3 +54,19 @@ Gets the aggregated metadata associated with a package in KV.
 ```
 make kv && ./bin/kv aggregate jquery
 ```
+
+## `sris`
+
+Lists all SRIs for files starting with a prefix.
+
+```
+make kv && ./bin/kv sris a-happy-tyler
+```
+
+```
+make kv && ./bin/kv sris a-happy-tyler/1.0.0
+```
+
+```
+make kv && ./bin/kv sris a-happy-tyler/1.0.0/happy.js
+```

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -21,8 +21,9 @@ func init() {
 
 func main() {
 	defer sentry.PanicHandler()
-	var metaOnly bool
-	flag.BoolVar(&metaOnly, "meta-only", false, "If set, only version metadata is uploaded to KV (no files).")
+	var metaOnly, srisOnly bool
+	flag.BoolVar(&metaOnly, "meta-only", false, "If set, only version metadata is uploaded to KV (no files, no SRIs).")
+	flag.BoolVar(&srisOnly, "sris-only", false, "If set, only file SRIs are uploaded to KV (no files, no metadata).")
 	flag.Parse()
 
 	if util.IsDebug() {
@@ -32,12 +33,16 @@ func main() {
 	switch subcommand := flag.Arg(0); subcommand {
 	case "upload":
 		{
+			if metaOnly && srisOnly {
+				panic("cannot set both -meta-only and -sris-only")
+			}
+
 			pckgs := flag.Args()[1:]
 			if len(pckgs) == 0 {
 				panic("no packages specified")
 			}
 
-			kv.InsertFromDisk(logger, pckgs, metaOnly)
+			kv.InsertFromDisk(logger, pckgs, metaOnly, srisOnly)
 		}
 	case "upload-aggregate":
 		{

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -83,6 +83,15 @@ func main() {
 
 			kv.OutputAggregate(pckg)
 		}
+	case "sris":
+		{
+			prefix := flag.Arg(1)
+			if prefix == "" {
+				panic("no prefix specified") // avoid listing all SRIs
+			}
+
+			kv.OutputSRIs(prefix)
+		}
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))
 	}

--- a/kv/aggregate.go
+++ b/kv/aggregate.go
@@ -42,7 +42,7 @@ func UpdateAggregatedMetadata(ctx context.Context, pckg *packages.Package, newAs
 // Reads an aggregated metadata entry in KV, ungzipping it and
 // unmarshalling it into a *packages.Package.
 func getAggregatedMetadata(key string) (*packages.Package, error) {
-	gzipBytes, err := Read(key, aggregatedMetadataNamespaceID)
+	gzipBytes, err := read(key, aggregatedMetadataNamespaceID)
 
 	if err != nil {
 		return nil, err

--- a/kv/files.go
+++ b/kv/files.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cdnjs/tools/compress"
+	"github.com/cdnjs/tools/sri"
 	"github.com/cdnjs/tools/util"
 )
 
@@ -33,12 +34,12 @@ func GetFiles(key string) ([]string, error) {
 	return ListByPrefix(key+"/", filesNamespaceID)
 }
 
-// Gets the requests to update a number of files in KV.
+// Gets the requests to update a number of files in KV, as well as the files' SRIs.
 // In order to do this, it will create a brotli and gzip version for each uncompressed file
 // that is not banned (ex. `.woff2`, `.br`, `.gz`).
-func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string) ([]*writeRequest, error) {
+func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string) ([]*writeRequest, []*writeRequest, error) {
 	baseVersionPath := path.Join(pkg, version)
-	var kvs []*writeRequest
+	var fileKVs, sriKVs []*writeRequest
 
 	for _, fromVersionPath := range fromVersionPaths {
 		ext := path.Ext(fromVersionPath)
@@ -52,14 +53,22 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 		// stat file
 		info, err := os.Stat(fullPath)
 		if err != nil {
-			return kvs, err
+			return nil, nil, err
 		}
 
 		// read file bytes
 		bytes, err := ioutil.ReadFile(fullPath)
 		if err != nil {
-			return kvs, err
+			return nil, nil, err
 		}
+
+		sriKVs = append(sriKVs, &writeRequest{
+			key:  baseFileKey,
+			name: fromVersionPath,
+			meta: &FileMetadata{
+				SRI: sri.CalculateSRI(bytes),
+			},
+		})
 
 		// set metadata
 		lastModifiedTime := info.ModTime()
@@ -67,52 +76,58 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 		lastModifiedStr := lastModifiedTime.Format(http.TimeFormat)
 		etag := fmt.Sprintf("%x-%x", lastModifiedSeconds, info.Size())
 
-		meta := &FileMetadata{
+		fileMeta := &FileMetadata{
 			ETag:         etag,
 			LastModified: lastModifiedStr,
 		}
 
 		if _, ok := doNotCompress[ext]; ok {
 			// will only insert uncompressed to KV
-			kvs = append(kvs, &writeRequest{
+			fileKVs = append(fileKVs, &writeRequest{
 				key:   baseFileKey,
 				name:  fromVersionPath,
 				value: bytes,
-				meta:  meta,
+				meta:  fileMeta,
 			})
 			continue
 		}
 
 		// brotli
-		kvs = append(kvs, &writeRequest{
+		fileKVs = append(fileKVs, &writeRequest{
 			key:   baseFileKey + ".br",
 			name:  fromVersionPath + ".br",
 			value: compress.Brotli11CLI(ctx, fullPath),
-			meta:  meta,
+			meta:  fileMeta,
 		})
 
 		// gzip
-		kvs = append(kvs, &writeRequest{
+		fileKVs = append(fileKVs, &writeRequest{
 			key:   baseFileKey + ".gz",
 			name:  fromVersionPath + ".gz",
 			value: compress.Gzip9Native(bytes),
-			meta:  meta,
+			meta:  fileMeta,
 		})
 	}
 
-	return kvs, nil
+	return fileKVs, sriKVs, nil
 }
 
 // Updates KV with new version's files.
 // The []string of `fromVersionPaths` will already contain the optimized/minified files by now.
-// The function will return the list of all files pushed to KV.
-func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string) ([]string, error) {
+// The function will return the list of all files pushed to KV and the list of SRIs pushed to KV.
+func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string) ([]string, []string, error) {
 	// create bulk of requests
-	reqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths)
+	fileReqs, sriReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	// write bulk to KV
-	return encodeAndWriteKVBulk(ctx, reqs, filesNamespaceID)
+	// write SRIs bulk to KV
+	successfulSRIWrites, err := encodeAndWriteKVBulk(ctx, sriReqs, srisNamespaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	successfulFileWrites, err := encodeAndWriteKVBulk(ctx, fileReqs, filesNamespaceID)
+	return successfulSRIWrites, successfulFileWrites, err
 }

--- a/kv/files.go
+++ b/kv/files.go
@@ -31,7 +31,7 @@ var (
 // GetFiles gets the list of KV file keys for a particular package.
 // The `key` must be the package/version (ex. `a-happy-tyler/1.0.0`)
 func GetFiles(key string) ([]string, error) {
-	return ListByPrefix(key+"/", filesNamespaceID)
+	return listByPrefixNamesOnly(key+"/", filesNamespaceID)
 }
 
 // Gets the requests to update a number of files in KV, as well as the files' SRIs.

--- a/kv/files.go
+++ b/kv/files.go
@@ -37,7 +37,7 @@ func GetFiles(key string) ([]string, error) {
 // Gets the requests to update a number of files in KV, as well as the files' SRIs.
 // In order to do this, it will create a brotli and gzip version for each uncompressed file
 // that is not banned (ex. `.woff2`, `.br`, `.gz`).
-func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string) ([]*writeRequest, []*writeRequest, error) {
+func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly bool) ([]*writeRequest, []*writeRequest, error) {
 	baseVersionPath := path.Join(pkg, version)
 	var sriKVs, fileKVs []*writeRequest
 
@@ -69,6 +69,10 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 				SRI: sri.CalculateSRI(bytes),
 			},
 		})
+
+		if srisOnly {
+			continue
+		}
 
 		// set metadata
 		lastModifiedTime := info.ModTime()
@@ -117,7 +121,7 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 // The function will return the list of all files pushed to KV and the list of SRIs pushed to KV.
 func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly bool) ([]string, []string, error) {
 	// create bulk of requests
-	fileReqs, sriReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths)
+	fileReqs, sriReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kv/files.go
+++ b/kv/files.go
@@ -119,7 +119,7 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 
 // Updates KV with new version's files.
 // The []string of `fromVersionPaths` will already contain the optimized/minified files by now.
-// The function will return the list of all files pushed to KV and the list of SRIs pushed to KV.
+// The function will return the list of SRIs pushed to KV and the list of all files pushed to KV.
 func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly bool) ([]string, []string, error) {
 	// create bulk of requests
 	sriReqs, fileReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)

--- a/kv/files.go
+++ b/kv/files.go
@@ -37,6 +37,7 @@ func GetFiles(key string) ([]string, error) {
 // Gets the requests to update a number of files in KV, as well as the files' SRIs.
 // In order to do this, it will create a brotli and gzip version for each uncompressed file
 // that is not banned (ex. `.woff2`, `.br`, `.gz`).
+// Returns the list of requests for pushing SRIs and list of requests for pushing files to KV.
 func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly bool) ([]*writeRequest, []*writeRequest, error) {
 	baseVersionPath := path.Join(pkg, version)
 	var sriKVs, fileKVs []*writeRequest
@@ -121,7 +122,7 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 // The function will return the list of all files pushed to KV and the list of SRIs pushed to KV.
 func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly bool) ([]string, []string, error) {
 	// create bulk of requests
-	fileReqs, sriReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)
+	sriReqs, fileReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -139,6 +139,7 @@ func listByPrefixNamesOnly(prefix, namespaceID string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	var names []string
 	for _, r := range results {
 		names = append(names, r.Name)

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -230,7 +230,7 @@ func encodeAndWriteKVBulk(ctx context.Context, kvs []*writeRequest, namespaceID 
 //
 // For example:
 // InsertNewVersionToKV("1000hz-bootstrap-validator", "0.10.0", "/tmp/1000hz-bootstrap-validator/0.10.0")
-func InsertNewVersionToKV(ctx context.Context, pkg, version, fullPathToVersion string, metaOnly bool) ([]string, []byte, []string, []string, error) {
+func InsertNewVersionToKV(ctx context.Context, pkg, version, fullPathToVersion string, metaOnly, srisOnly bool) ([]string, []byte, []string, []string, error) {
 	fromVersionPaths, err := util.ListFilesInVersion(ctx, fullPathToVersion)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -246,6 +246,6 @@ func InsertNewVersionToKV(ctx context.Context, pkg, version, fullPathToVersion s
 	}
 
 	// write files to KV
-	srisPushedToKV, filesPushedToKV, err := updateKVFiles(ctx, pkg, version, fullPathToVersion, fromVersionPaths)
+	srisPushedToKV, filesPushedToKV, err := updateKVFiles(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)
 	return fromVersionPaths, versionBytes, srisPushedToKV, filesPushedToKV, err
 }

--- a/kv/packages.go
+++ b/kv/packages.go
@@ -12,7 +12,7 @@ import (
 // a packages.InvalidSchemaError if the schema is invalid, a KeyNotFoundError
 // if the KV key is not found, and an AuthError if there is an authentication error.
 func GetPackage(ctx context.Context, key string) (*packages.Package, error) {
-	bytes, err := Read(key, packagesNamespaceID)
+	bytes, err := read(key, packagesNamespaceID)
 
 	if err != nil {
 		return nil, err

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -17,7 +17,7 @@ import (
 
 // InsertFromDisk is a helper tool to insert a number of packages from disk.
 // Note: Only inserting versions (not updating package metadata).
-func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly bool) {
+func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly bool) {
 	basePath := util.GetCDNJSLibrariesPath()
 
 	for i, pckgname := range pckgs {
@@ -33,7 +33,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly bool) {
 		for j, version := range versions {
 			util.Infof(ctx, "p(%d/%d) v(%d/%d) Inserting %s (%s)\n", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version)
 			dir := path.Join(basePath, *pckg.Name, version)
-			_, _, _, _, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly)
+			_, _, _, _, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly, srisOnly)
 			util.Check(err)
 		}
 	}

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -102,7 +102,7 @@ func InsertAggregateMetadataFromScratch(logger *log.Logger, pckgs []string) {
 
 // OutputAllAggregatePackages outputs all the names of all aggregated package metadata entries in KV.
 func OutputAllAggregatePackages() {
-	res, err := ListByPrefix("", aggregatedMetadataNamespaceID)
+	res, err := listByPrefixNamesOnly("", aggregatedMetadataNamespaceID)
 	util.Check(err)
 
 	bytes, err := json.Marshal(res)
@@ -113,7 +113,7 @@ func OutputAllAggregatePackages() {
 
 // OutputAllPackages outputs the names of all packages in KV.
 func OutputAllPackages() {
-	res, err := ListByPrefix("", packagesNamespaceID)
+	res, err := listByPrefixNamesOnly("", packagesNamespaceID)
 	util.Check(err)
 
 	bytes, err := json.Marshal(res)
@@ -179,7 +179,7 @@ func OutputAllMeta(logger *log.Logger, pckgName string) {
 
 // OutputAggregate outputs the aggregated metadata associated with a package.
 func OutputAggregate(pckgName string) {
-	bytes, err := Read(pckgName, aggregatedMetadataNamespaceID)
+	bytes, err := read(pckgName, aggregatedMetadataNamespaceID)
 	util.Check(err)
 
 	uncompressed := compress.UnGzip(bytes)
@@ -189,4 +189,15 @@ func OutputAggregate(pckgName string) {
 	util.Check(json.Unmarshal(uncompressed, &p))
 
 	fmt.Printf("%s\n", uncompressed)
+}
+
+// OutputSRIs lists the SRIs namespace by prefix.
+func OutputSRIs(prefix string) {
+	res, err := listByPrefix(prefix, srisNamespaceID)
+	util.Check(err)
+
+	bytes, err := json.Marshal(res)
+	util.Check(err)
+
+	fmt.Printf("%s\n", bytes)
 }

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -196,7 +196,12 @@ func OutputSRIs(prefix string) {
 	res, err := listByPrefix(prefix, srisNamespaceID)
 	util.Check(err)
 
-	bytes, err := json.Marshal(res)
+	sris := make(map[string]string)
+	for _, r := range res {
+		sris[r.Name] = r.Metadata.(map[string]interface{})["sri"].(string)
+	}
+
+	bytes, err := json.Marshal(sris)
 	util.Check(err)
 
 	fmt.Printf("%s\n", bytes)

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -33,7 +33,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly bool) {
 		for j, version := range versions {
 			util.Infof(ctx, "p(%d/%d) v(%d/%d) Inserting %s (%s)\n", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version)
 			dir := path.Join(basePath, *pckg.Name, version)
-			_, _, _, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly)
+			_, _, _, _, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly)
 			util.Check(err)
 		}
 	}

--- a/kv/versions.go
+++ b/kv/versions.go
@@ -11,12 +11,12 @@ import (
 
 // GetVersions gets the list of KV version keys for a particular package.
 func GetVersions(pckgname string) ([]string, error) {
-	return ListByPrefix(pckgname+"/", versionsNamespaceID)
+	return listByPrefixNamesOnly(pckgname+"/", versionsNamespaceID)
 }
 
 // GetVersion gets metadata for a particular version.
 func GetVersion(ctx context.Context, key string) ([]string, error) {
-	bytes, err := Read(key, versionsNamespaceID)
+	bytes, err := read(key, versionsNamespaceID)
 	if err != nil {
 		return nil, err
 	}

--- a/sri/sri.go
+++ b/sri/sri.go
@@ -4,23 +4,25 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
-	"io"
-	"os"
+	"io/ioutil"
 
 	"github.com/cdnjs/tools/util"
 )
 
 // CalculateFileSRI generates a Subresource Integrity string for a particular file.
 func CalculateFileSRI(filename string) string {
-	f, err := os.Open(filename)
+	bytes, err := ioutil.ReadFile(filename)
 	util.Check(err)
-	defer f.Close()
 
+	return CalculateSRI(bytes)
+}
+
+// CalculateSRI calculates a Subresource Integrity string from bytes.
+func CalculateSRI(bytes []byte) string {
 	h := sha512.New()
-	_, err = io.Copy(h, f)
+	_, err := h.Write(bytes)
 	util.Check(err)
 
 	sri := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
 	return fmt.Sprintf("sha512-%s", sri)
 }


### PR DESCRIPTION
- namespace will consist of entries for every file in the files namespace
- each entry will contain metadata for an SRI (no values)

This separate namespace is to get the API running with SRIs.
When we migrate all files to KV, we can store the SRIs in the file metadata itself.

- Need to set in bot-ansible: `WORKERS_KV_SRIS_NAMESPACE_ID`