### PR TITLE
More upload flags (count, no-push, panic-oversized)

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -383,7 +383,7 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 		pkg, version := *newVersionToCommit.pckg.Name, newVersionToCommit.newVersion
 
 		util.Debugf(ctx, "writing version to KV %s", path.Join(pkg, version))
-		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false, false, false)
+		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, _, _, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false, false, false, false)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write kv version %s: %s", path.Join(pkg, version), err.Error()))
 		}

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -383,7 +383,7 @@ func writeNewVersionsToKV(ctx context.Context, newVersionsToCommit []newVersionT
 		pkg, version := *newVersionToCommit.pckg.Name, newVersionToCommit.newVersion
 
 		util.Debugf(ctx, "writing version to KV %s", path.Join(pkg, version))
-		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, _, _, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false, false, false, false)
+		kvVersionFiles, kvVersionMetadata, kvSRIs, kvCompressedFiles, _, _, err := kv.InsertNewVersionToKV(ctx, pkg, version, newVersionToCommit.versionPath, false, false, false, false, false)
 		if err != nil {
 			panic(fmt.Sprintf("failed to write kv version %s: %s", path.Join(pkg, version), err.Error()))
 		}

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -8,7 +8,7 @@ Inserts packages from disk to KV. Package files and version metadata will be pus
 If the flag `-meta-only` is set, only version metadata will be pushed to KV.
 If the flag `-sris-only` is set, only SRIs are pushed to KV.
 If the flag `-files-only` is set, only files are pushed to KV.
-These three flags are mutually exclusive.
+If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (< 10MiB).
 
 ```
 make kv && ./bin/kv upload jquery mathjax font-awesome
@@ -20,7 +20,7 @@ Insert a specific package version from disk to KV. Package files and version met
 If the flag `-meta-only` is set, only version metadata will be pushed to KV.
 If the flag `-sris-only` is set, only SRIs are pushed to KV.
 If the flag `-files-only` is set, only files are pushed to KV.
-These three flags are mutually exclusive.
+If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (< 10MiB).
 
 ```
 make kv && ./bin/kv upload-version jquery 3.5.1

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -8,7 +8,9 @@ Inserts packages from disk to KV. Package files and version metadata will be pus
 If the flag `-meta-only` is set, only version metadata will be pushed to KV.
 If the flag `-sris-only` is set, only SRIs are pushed to KV.
 If the flag `-files-only` is set, only files are pushed to KV.
-If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (< 10MiB).
+If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (<= 10MiB).
+If the flag `-no-push` is set, nothing will be written to KV. However, theoretical keys will be counted if the `-count` flag is set.
+If the flag `-panic-oversized` is set, the program will panic if any KV compressed file is oversized (> 10MiB). Note that the program will already panic for oversized entries in other namespaces.
 
 ```
 make kv && ./bin/kv upload jquery mathjax font-awesome
@@ -20,7 +22,8 @@ Insert a specific package version from disk to KV. Package files and version met
 If the flag `-meta-only` is set, only version metadata will be pushed to KV.
 If the flag `-sris-only` is set, only SRIs are pushed to KV.
 If the flag `-files-only` is set, only files are pushed to KV.
-If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (< 10MiB).
+If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (<= 10MiB).
+If the flag `-no-push` is set, nothing will be written to KV. However, theoretical keys will be counted if the `-count` flag is set.
 
 ```
 make kv && ./bin/kv upload-version jquery 3.5.1

--- a/cmd/kv/README.md
+++ b/cmd/kv/README.md
@@ -24,6 +24,7 @@ If the flag `-sris-only` is set, only SRIs are pushed to KV.
 If the flag `-files-only` is set, only files are pushed to KV.
 If the flag `-count` is set, the the count of KV keys that should be in KV will be outputted at the end of the program. This will assume all entries can fit into KV (<= 10MiB).
 If the flag `-no-push` is set, nothing will be written to KV. However, theoretical keys will be counted if the `-count` flag is set.
+If the flag `-panic-oversized` is set, the program will panic if any KV compressed file is oversized (> 10MiB). Note that the program will already panic for oversized entries in other namespaces.
 
 ```
 make kv && ./bin/kv upload-version jquery 3.5.1

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -35,11 +35,12 @@ func isZeroOrOne(bs []bool) bool {
 
 func main() {
 	defer sentry.PanicHandler()
-	var metaOnly, srisOnly, filesOnly, count, noPush, ungzip, unbrotli bool
+	var metaOnly, srisOnly, filesOnly, count, noPush, panicOversized, ungzip, unbrotli bool
 	flag.BoolVar(&metaOnly, "meta-only", false, "If set, only version metadata is uploaded to KV (no files, no SRIs).")
 	flag.BoolVar(&srisOnly, "sris-only", false, "If set, only file SRIs are uploaded to KV (no files, no metadata).")
 	flag.BoolVar(&filesOnly, "files-only", false, "If set, only files are uploaded to KV (no metadata, no SRIs).")
-	flag.BoolVar(&count, "count", false, "If set, the the count of KV keys that should be in KV will be outputted. Will assume all entries can fit into KV (<10MiB).")
+	flag.BoolVar(&count, "count", false, "If set, the the count of theoretical KV keys that should be in KV will be outputted. Will assume all entries can fit into KV (<= 10MiB).")
+	flag.BoolVar(&panicOversized, "panic-oversized", false, "If set, the program will panic if any KV compressed file is oversized (> 10MiB).")
 	flag.BoolVar(&noPush, "no-push", false, "If set, nothing will be written to KV. However, theoretical keys will be counted if the -count flag is set.")
 	flag.BoolVar(&ungzip, "ungzip", false, "If set, the file content will be decompressed with gzip.")
 	flag.BoolVar(&unbrotli, "unbrotli", false, "If set, the file content will be decompressed with brotli.")
@@ -61,7 +62,7 @@ func main() {
 				panic("no packages specified")
 			}
 
-			kv.InsertFromDisk(logger, pckgs, metaOnly, srisOnly, filesOnly, count, noPush)
+			kv.InsertFromDisk(logger, pckgs, metaOnly, srisOnly, filesOnly, count, noPush, panicOversized)
 		}
 	case "upload-version":
 		{
@@ -70,7 +71,7 @@ func main() {
 				panic("must specify package and version")
 			}
 
-			kv.InsertVersionFromDisk(logger, args[0], args[1], metaOnly, srisOnly, filesOnly, count, noPush)
+			kv.InsertVersionFromDisk(logger, args[0], args[1], metaOnly, srisOnly, filesOnly, count, noPush, panicOversized)
 		}
 	case "upload-aggregate":
 		{

--- a/cmd/kv/main.go
+++ b/cmd/kv/main.go
@@ -35,10 +35,12 @@ func isZeroOrOne(bs []bool) bool {
 
 func main() {
 	defer sentry.PanicHandler()
-	var metaOnly, srisOnly, filesOnly, ungzip, unbrotli bool
+	var metaOnly, srisOnly, filesOnly, count, noPush, ungzip, unbrotli bool
 	flag.BoolVar(&metaOnly, "meta-only", false, "If set, only version metadata is uploaded to KV (no files, no SRIs).")
 	flag.BoolVar(&srisOnly, "sris-only", false, "If set, only file SRIs are uploaded to KV (no files, no metadata).")
 	flag.BoolVar(&filesOnly, "files-only", false, "If set, only files are uploaded to KV (no metadata, no SRIs).")
+	flag.BoolVar(&count, "count", false, "If set, the the count of KV keys that should be in KV will be outputted. Will assume all entries can fit into KV (<10MiB).")
+	flag.BoolVar(&noPush, "no-push", false, "If set, nothing will be written to KV. However, theoretical keys will be counted if the -count flag is set.")
 	flag.BoolVar(&ungzip, "ungzip", false, "If set, the file content will be decompressed with gzip.")
 	flag.BoolVar(&unbrotli, "unbrotli", false, "If set, the file content will be decompressed with brotli.")
 	flag.Parse()
@@ -59,7 +61,7 @@ func main() {
 				panic("no packages specified")
 			}
 
-			kv.InsertFromDisk(logger, pckgs, metaOnly, srisOnly, filesOnly)
+			kv.InsertFromDisk(logger, pckgs, metaOnly, srisOnly, filesOnly, count, noPush)
 		}
 	case "upload-version":
 		{
@@ -68,7 +70,7 @@ func main() {
 				panic("must specify package and version")
 			}
 
-			kv.InsertVersionFromDisk(logger, args[0], args[1], metaOnly, srisOnly, filesOnly)
+			kv.InsertVersionFromDisk(logger, args[0], args[1], metaOnly, srisOnly, filesOnly, count, noPush)
 		}
 	case "upload-aggregate":
 		{

--- a/kv/aggregate.go
+++ b/kv/aggregate.go
@@ -71,5 +71,5 @@ func writeAggregatedMetadata(ctx context.Context, p *packages.Package) ([]string
 	}
 
 	// write aggregated to KV
-	return encodeAndWriteKVBulk(ctx, []*writeRequest{req}, aggregatedMetadataNamespaceID)
+	return encodeAndWriteKVBulk(ctx, []*writeRequest{req}, aggregatedMetadataNamespaceID, true)
 }

--- a/kv/files.go
+++ b/kv/files.go
@@ -127,25 +127,26 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 // Updates KV with new version's files.
 // The []string of `fromVersionPaths` will already contain the optimized/minified files by now.
 // The function will return the list of SRIs pushed to KV and the list of all files pushed to KV.
-func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly, filesOnly bool) ([]string, []string, error) {
+func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly, filesOnly, noPush bool) ([]string, []string, int, int, error) {
 	// create bulk of requests
 	sriReqs, fileReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, 0, err
 	}
+	theoreticalSRIsKeys, theoreticalFilesKeys := len(sriReqs), len(fileReqs)
 
 	var successfulSRIWrites []string
-	if !filesOnly {
+	if !filesOnly && !noPush {
 		// write SRIs bulk to KV
 		successfulSRIWrites, err = encodeAndWriteKVBulk(ctx, sriReqs, srisNamespaceID)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, 0, err
 		}
 		if srisOnly {
-			return successfulSRIWrites, nil, nil
+			return successfulSRIWrites, nil, 0, 0, nil
 		}
 	}
 
 	successfulFileWrites, err := encodeAndWriteKVBulk(ctx, fileReqs, filesNamespaceID)
-	return successfulSRIWrites, successfulFileWrites, err
+	return successfulSRIWrites, successfulFileWrites, theoreticalSRIsKeys, theoreticalFilesKeys, err
 }

--- a/kv/files.go
+++ b/kv/files.go
@@ -135,8 +135,19 @@ func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, 
 	}
 	theoreticalSRIsKeys, theoreticalFilesKeys := len(sriReqs), len(fileReqs)
 
+	if noPush {
+		if panicOversized {
+			for _, f := range fileReqs {
+				if size := int64(len(f.value)); size > util.MaxFileSize {
+					panic(fmt.Sprintf("file request oversized: %s (%d)", f.key, size))
+				}
+			}
+		}
+		return nil, nil, theoreticalSRIsKeys, theoreticalFilesKeys, nil
+	}
+
 	var successfulSRIWrites []string
-	if !filesOnly && !noPush {
+	if !filesOnly {
 		// write SRIs bulk to KV
 		successfulSRIWrites, err = encodeAndWriteKVBulk(ctx, sriReqs, srisNamespaceID, panicOversized)
 		if err != nil {

--- a/kv/files.go
+++ b/kv/files.go
@@ -127,7 +127,7 @@ func getFileWriteRequests(ctx context.Context, pkg, version, fullPathToVersion s
 // Updates KV with new version's files.
 // The []string of `fromVersionPaths` will already contain the optimized/minified files by now.
 // The function will return the list of SRIs pushed to KV and the list of all files pushed to KV.
-func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly, filesOnly, noPush bool) ([]string, []string, int, int, error) {
+func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, fromVersionPaths []string, srisOnly, filesOnly, noPush, panicOversized bool) ([]string, []string, int, int, error) {
 	// create bulk of requests
 	sriReqs, fileReqs, err := getFileWriteRequests(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly)
 	if err != nil {
@@ -138,7 +138,7 @@ func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, 
 	var successfulSRIWrites []string
 	if !filesOnly && !noPush {
 		// write SRIs bulk to KV
-		successfulSRIWrites, err = encodeAndWriteKVBulk(ctx, sriReqs, srisNamespaceID)
+		successfulSRIWrites, err = encodeAndWriteKVBulk(ctx, sriReqs, srisNamespaceID, panicOversized)
 		if err != nil {
 			return nil, nil, 0, 0, err
 		}
@@ -147,6 +147,6 @@ func updateKVFiles(ctx context.Context, pkg, version, fullPathToVersion string, 
 		}
 	}
 
-	successfulFileWrites, err := encodeAndWriteKVBulk(ctx, fileReqs, filesNamespaceID)
+	successfulFileWrites, err := encodeAndWriteKVBulk(ctx, fileReqs, filesNamespaceID, panicOversized)
 	return successfulSRIWrites, successfulFileWrites, theoreticalSRIsKeys, theoreticalFilesKeys, err
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -255,26 +255,26 @@ func encodeAndWriteKVBulk(ctx context.Context, kvs []*writeRequest, namespaceID 
 //
 // For example:
 // InsertNewVersionToKV("1000hz-bootstrap-validator", "0.10.0", "/tmp/1000hz-bootstrap-validator/0.10.0")
-func InsertNewVersionToKV(ctx context.Context, pkg, version, fullPathToVersion string, metaOnly, srisOnly, filesOnly bool) ([]string, []byte, []string, []string, error) {
+func InsertNewVersionToKV(ctx context.Context, pkg, version, fullPathToVersion string, metaOnly, srisOnly, filesOnly, noPush bool) ([]string, []byte, []string, []string, int, int, error) {
 	fromVersionPaths, err := util.ListFilesInVersion(ctx, fullPathToVersion)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, 0, 0, err
 	}
 	sort.Strings(fromVersionPaths)
 
 	var versionBytes []byte
-	if !filesOnly && !srisOnly {
+	if !filesOnly && !srisOnly && !noPush {
 		// write version metadata to KV
 		versionBytes, err = updateKVVersion(ctx, pkg, version, fromVersionPaths)
 		if err != nil {
-			return nil, nil, nil, nil, err
+			return nil, nil, nil, nil, 0, 0, err
 		}
 		if metaOnly {
-			return fromVersionPaths, versionBytes, nil, nil, nil
+			return fromVersionPaths, versionBytes, nil, nil, 0, 0, nil
 		}
 	}
 
 	// write files to KV
-	srisPushedToKV, filesPushedToKV, err := updateKVFiles(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly, filesOnly)
-	return fromVersionPaths, versionBytes, srisPushedToKV, filesPushedToKV, err
+	srisPushedToKV, filesPushedToKV, theoreticalSRIKeys, theoreticalFileKeys, err := updateKVFiles(ctx, pkg, version, fullPathToVersion, fromVersionPaths, srisOnly, filesOnly, noPush)
+	return fromVersionPaths, versionBytes, srisPushedToKV, filesPushedToKV, theoreticalSRIKeys, theoreticalFileKeys, err
 }

--- a/kv/packages.go
+++ b/kv/packages.go
@@ -42,6 +42,6 @@ func UpdateKVPackage(ctx context.Context, p *packages.Package) error {
 		value: v,
 	}
 
-	_, err = encodeAndWriteKVBulk(ctx, []*writeRequest{req}, packagesNamespaceID)
+	_, err = encodeAndWriteKVBulk(ctx, []*writeRequest{req}, packagesNamespaceID, true)
 	return err
 }

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -18,7 +18,7 @@ import (
 )
 
 // InsertVersionFromDisk is a helper tool to insert a single version from disk.
-func InsertVersionFromDisk(logger *log.Logger, pckgName, pckgVersion string, metaOnly, srisOnly, filesOnly, count, noPush bool) {
+func InsertVersionFromDisk(logger *log.Logger, pckgName, pckgVersion string, metaOnly, srisOnly, filesOnly, count, noPush, panicOversized bool) {
 	ctx := util.ContextWithEntries(util.GetStandardEntries(pckgName, logger)...)
 
 	pckg, err := GetPackage(ctx, pckgName)
@@ -39,7 +39,7 @@ func InsertVersionFromDisk(logger *log.Logger, pckgName, pckgVersion string, met
 
 	basePath := util.GetCDNJSLibrariesPath()
 	dir := path.Join(basePath, *pckg.Name, pckgVersion)
-	_, _, _, _, theoreticalSRIKeys, theoreticalFileKeys, err := InsertNewVersionToKV(ctx, *pckg.Name, pckgVersion, dir, metaOnly, srisOnly, filesOnly, noPush)
+	_, _, _, _, theoreticalSRIKeys, theoreticalFileKeys, err := InsertNewVersionToKV(ctx, *pckg.Name, pckgVersion, dir, metaOnly, srisOnly, filesOnly, noPush, panicOversized)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to insert %s (%s): %s", *pckg.Name, pckgVersion, err))
 	}
@@ -58,7 +58,7 @@ type uploadResult struct {
 
 // InsertFromDisk is a helper tool to insert a number of packages from disk.
 // Note: Only inserting versions (not updating package metadata).
-func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly, filesOnly, count, noPush bool) {
+func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly, filesOnly, count, noPush, panicOversized bool) {
 	basePath := util.GetCDNJSLibrariesPath()
 
 	var wg sync.WaitGroup
@@ -92,7 +92,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly, file
 			for j, version := range versions {
 				util.Debugf(ctx, "p(%d/%d) v(%d/%d) Inserting %s (%s)\n", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version)
 				dir := path.Join(basePath, *pckg.Name, version)
-				_, _, _, _, theoreticalSRIKeys, theoreticalFileKeys, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly, srisOnly, filesOnly, noPush)
+				_, _, _, _, theoreticalSRIKeys, theoreticalFileKeys, err := InsertNewVersionToKV(ctx, *pckg.Name, version, dir, metaOnly, srisOnly, filesOnly, noPush, panicOversized)
 				pckgTotalSRIKeys += theoreticalSRIKeys
 				pckgTotalFileKeys += theoreticalFileKeys
 

--- a/kv/versions.go
+++ b/kv/versions.go
@@ -43,6 +43,6 @@ func updateVersionRequest(pkg, version string, fromVersionPaths []string) *write
 // The []string of `fromVersionPaths` will already contain the optimized/minified files by now.
 func updateKVVersion(ctx context.Context, pkg, version string, fromVersionPaths []string) ([]byte, error) {
 	req := updateVersionRequest(pkg, version, fromVersionPaths)
-	_, err := encodeAndWriteKVBulk(ctx, []*writeRequest{req}, versionsNamespaceID)
+	_, err := encodeAndWriteKVBulk(ctx, []*writeRequest{req}, versionsNamespaceID, true)
 	return req.value, err
 }


### PR DESCRIPTION
- `-count` flag to count theoretical kv sri/file keys
- `-no-push` flag to use the upload command without actually pushing to KV
- `-panic-oversized` flag to panic the program if a compressed file will not fit into KV

Addresses #195 