### PR TITLE
convert upload to worker pool

### DIFF
--- a/kv/tools.go
+++ b/kv/tools.go
@@ -120,6 +120,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly, file
 			Name:  name,
 		}
 	}
+	close(jobs)
 
 	var totalSRIKeys, totalFileKeys int
 
@@ -130,6 +131,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly, file
 		totalSRIKeys += res.TheoreticalSRIKeys
 		totalFileKeys += res.TheoreticalFileKeys
 	}
+	close(done)
 
 	log.Println("Done.")
 


### PR DESCRIPTION
- ran into this error `panic: fork/exec /usr/bin/brotli: too many open files` so I limited the worker goroutines