### PR TITLE
backfill missing versions, not just new versions

### DIFF
--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -69,9 +69,11 @@ func updateGit(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 
 		for i := len(versionDiff) - 1; i >= 0; i-- {
 			v := versionDiff[i]
-			if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
-				newGitVersions = append(newGitVersions, v)
-			}
+			// Backfill missing versions.
+			//
+			//if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
+			newGitVersions = append(newGitVersions, v)
+			//}
 		}
 
 		util.Debugf(ctx, "new versions: %s\n", newGitVersions)

--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -67,13 +67,17 @@ func updateGit(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 
 		newGitVersions := make([]git.Version, 0)
 
+		backfilled := 0
 		for i := len(versionDiff) - 1; i >= 0; i-- {
 			v := versionDiff[i]
-			// Backfill missing versions.
-			//
-			//if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
+			if !v.TimeStamp.After(lastExistingVersion.TimeStamp) {
+				// Backfill missing versions.
+				if backfilled == util.ImportAllMaxVersions {
+					continue
+				}
+				backfilled++
+			}
 			newGitVersions = append(newGitVersions, v)
-			//}
 		}
 
 		util.Debugf(ctx, "new versions: %s\n", newGitVersions)

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -17,6 +17,7 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	var allVersions []version
 
 	existingVersionSet := pckg.Versions()
+
 	util.Debugf(ctx, "existing npm versions: %v\n", existingVersionSet)
 
 	npmVersions, _ := npm.GetVersions(ctx, *pckg.Autoupdate.Target)
@@ -37,9 +38,11 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 
 		for i := len(versionDiff) - 1; i >= 0; i-- {
 			v := versionDiff[i]
-			if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
-				newNpmVersions = append(newNpmVersions, v)
-			}
+			// Backfill missing versions.
+			//
+			// if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
+			newNpmVersions = append(newNpmVersions, v)
+			// }
 		}
 
 		sort.Sort(sort.Reverse(npm.ByTimeStamp(npmVersions)))

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -51,10 +51,6 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 
 		sort.Sort(sort.Reverse(npm.ByTimeStamp(newNpmVersions)))
 
-		if len(newNpmVersions) > util.ImportAllMaxVersions {
-			newNpmVersions = newNpmVersions[len(newNpmVersions)-util.ImportAllMaxVersions:]
-		}
-
 		newVersionsToCommit = doUpdateNpm(ctx, pckg, newNpmVersions)
 	} else {
 		if len(existingVersionSet) > 0 {


### PR DESCRIPTION
Addresses [missing version of mathjax](https://github.com/cdnjs/packages/issues/417).

@xtuc we need to be careful/think about this, we shouldn't publish too many outdated versions ....