### PR TITLE
Fix missing latest version

### DIFF
--- a/cmd/autoupdate/git.go
+++ b/cmd/autoupdate/git.go
@@ -53,15 +53,15 @@ func updateGit(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	existingVersionSet := pckg.Versions()
 
 	util.Debugf(ctx, "existing git versions: %v\n", existingVersionSet)
-	lastExistingVersion, allExisting := git.GetMostRecentExistingVersion(ctx, existingVersionSet, gitVersions)
+	lastExistingVersionInGit, allExistingInCDNJS := git.GetMostRecentExistingVersion(ctx, existingVersionSet, gitVersions)
 
 	// add all existing versions to all versions list
-	for _, v := range allExisting {
+	for _, v := range allExistingInCDNJS {
 		allVersions = append(allVersions, version(v))
 	}
 
-	if lastExistingVersion != nil {
-		util.Debugf(ctx, "last existing version: %s\n", lastExistingVersion.Version)
+	if lastExistingVersionInGit != nil {
+		util.Debugf(ctx, "last existing version: %s\n", lastExistingVersionInGit.Version)
 
 		versionDiff := gitVersionDiff(gitVersions, existingVersionSet)
 
@@ -69,7 +69,7 @@ func updateGit(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 
 		for i := len(versionDiff) - 1; i >= 0; i-- {
 			v := versionDiff[i]
-			if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
+			if v.TimeStamp.After(lastExistingVersionInGit.TimeStamp) {
 				newGitVersions = append(newGitVersions, v)
 			}
 		}

--- a/cmd/autoupdate/npm.go
+++ b/cmd/autoupdate/npm.go
@@ -20,15 +20,15 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 	util.Debugf(ctx, "existing npm versions: %v\n", existingVersionSet)
 
 	npmVersions, _ := npm.GetVersions(ctx, *pckg.Autoupdate.Target)
-	lastExistingVersion, allExisting := npm.GetMostRecentExistingVersion(ctx, existingVersionSet, npmVersions)
+	lastExistingVersionInNpm, allExistingInCDNJS := npm.GetMostRecentExistingVersion(ctx, existingVersionSet, npmVersions)
 
 	// add all existing versions to all versions list
-	for _, v := range allExisting {
+	for _, v := range allExistingInCDNJS {
 		allVersions = append(allVersions, version(v))
 	}
 
-	if lastExistingVersion != nil {
-		util.Debugf(ctx, "last existing version: %s\n", lastExistingVersion.Version)
+	if lastExistingVersionInNpm != nil {
+		util.Debugf(ctx, "last existing version: %s\n", lastExistingVersionInNpm.Version)
 
 		versionDiff := npmVersionDiff(npmVersions, existingVersionSet)
 		sort.Sort(npm.ByTimeStamp(versionDiff))
@@ -37,7 +37,7 @@ func updateNpm(ctx context.Context, pckg *packages.Package) ([]newVersionToCommi
 
 		for i := len(versionDiff) - 1; i >= 0; i-- {
 			v := versionDiff[i]
-			if v.TimeStamp.After(lastExistingVersion.TimeStamp) {
+			if v.TimeStamp.After(lastExistingVersionInNpm.TimeStamp) {
 				newNpmVersions = append(newNpmVersions, v)
 			}
 		}

--- a/git/sort.go
+++ b/git/sort.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"time"
 
 	"github.com/cdnjs/tools/util"
 )
@@ -25,6 +26,7 @@ func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string
 		gitMap[v.Version] = v
 	}
 
+	// All existing, whether in git or not.
 	var allExisting []Version
 
 	// find most recent version
@@ -35,9 +37,13 @@ func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string
 			if mostRecent == nil || version.TimeStamp.After(mostRecent.TimeStamp) {
 				mostRecent = &version // new most recent found
 			}
-			continue
+		} else {
+			util.Debugf(ctx, "existing version not found on git: %s", existingVersion)
+			allExisting = append(allExisting, Version{
+				Version:   existingVersion,
+				TimeStamp: time.Time{},
+			})
 		}
-		util.Debugf(ctx, "existing version not found on git: %s", existingVersion)
 	}
 
 	return mostRecent, allExisting

--- a/npm/sort.go
+++ b/npm/sort.go
@@ -2,6 +2,7 @@ package npm
 
 import (
 	"context"
+	"time"
 
 	"github.com/cdnjs/tools/util"
 )
@@ -25,6 +26,7 @@ func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string
 		npmMap[v.Version] = v
 	}
 
+	// All existing, whether in npm or not.
 	var allExisting []Version
 
 	// find most recent version
@@ -35,9 +37,13 @@ func GetMostRecentExistingVersion(ctx context.Context, existingVersions []string
 			if mostRecent == nil || version.TimeStamp.After(mostRecent.TimeStamp) {
 				mostRecent = &version // new most recent found
 			}
-			continue
+		} else {
+			util.Debugf(ctx, "existing version not found on npm: %s", existingVersion)
+			allExisting = append(allExisting, Version{
+				Version:   existingVersion,
+				TimeStamp: time.Time{},
+			})
 		}
-		util.Debugf(ctx, "existing version not found on npm: %s", existingVersion)
 	}
 
 	return mostRecent, allExisting


### PR DESCRIPTION
Attempting to fix #193 

- was not being corrected automatically because some packages only consist of versions that do not exist anymore on npm/git (and the new versions either didn't exist or no files were matched)
- add versions that don't exist on npm/git anymore but exist in CDNJS to []allVersions, so the metadata for latest version is corrected