### PR TITLE
Update algolia in-place by the bot

### DIFF
--- a/algolia/client.go
+++ b/algolia/client.go
@@ -26,6 +26,11 @@ func GetClient() *search.Client {
 	return search.NewClient("2QWLVLXZB6", util.GetEnv("ALGOLIA_WRITE_API_KEY"))
 }
 
+// GetProdIndex gets the Algolia production index.
+func GetProdIndex(client *search.Client) *search.Index {
+	return client.InitIndex(prodIndex)
+}
+
 // GetTmpIndex instantiates and configures a new temporary Algolia Search index.
 func GetTmpIndex(client *search.Client) *search.Index {
 	index := client.InitIndex(tmpIndex)

--- a/algolia/index.go
+++ b/algolia/index.go
@@ -113,7 +113,7 @@ func getSRI(p *packages.Package) (string, error) {
 }
 
 // IndexPackage saves a package to the Algolia.
-func IndexPackage(p packages.Package, index *search.Index) error {
+func IndexPackage(p *packages.Package, index *search.Index) error {
 	var author string
 	if p.Author != nil {
 		author = *p.Author
@@ -144,7 +144,7 @@ func IndexPackage(p packages.Package, index *search.Index) error {
 		}
 	}
 
-	sri, srierr := getSRI(&p)
+	sri, srierr := getSRI(p)
 	if srierr != nil {
 		fmt.Printf("%s", srierr)
 	}

--- a/algolia/index.go
+++ b/algolia/index.go
@@ -1,0 +1,172 @@
+package algolia
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/cdnjs/tools/github"
+	"github.com/cdnjs/tools/packages"
+	"github.com/cdnjs/tools/sentry"
+	"github.com/cdnjs/tools/util"
+)
+
+func init() {
+	sentry.Init()
+}
+
+// SearchEntry represents an entry in the Algolia Search index.
+type SearchEntry struct {
+	Name             string               `json:"name"`
+	Filename         string               `json:"filename"`
+	Description      string               `json:"description"`
+	Version          string               `json:"version"`
+	Keywords         []string             `json:"keywords"`
+	AlternativeNames []string             `json:"alternativeNames"`
+	FileType         string               `json:"fileType"`
+	Github           *GitHubMeta          `json:"github"`
+	ObjectID         string               `json:"objectID"`
+	License          string               `json:"license"`
+	Homepage         string               `json:"homepage"`
+	Namespace        string               `json:"namespace,omitempty"`
+	Repository       *packages.Repository `json:"repository"`
+	Author           string               `json:"author"`
+	OriginalName     string               `json:"originalName"`
+	Sri              string               `json:"sri"`
+}
+
+// GitHubMeta contains metadata for a particular GitHub repository.
+type GitHubMeta struct {
+	User             string `json:"user"`
+	Repo             string `json:"repo"`
+	StargazersCount  int    `json:"stargazers_count"`
+	Forks            int    `json:"forks"`
+	SubscribersCount int    `json:"subscribers_count"`
+}
+
+var (
+	re1 = regexp.MustCompile(`[^a-zA-Z]`)
+	re2 = regexp.MustCompile(`(^[^A-Z]*|[A-Z]*)([A-Z][^A-Z]+|$)`)
+)
+
+func getAlternativeNames(name string) []string {
+	names := make([]string, 0)
+	names = append(names, re1.ReplaceAllString(name, `$1 $2`))
+	names = append(names, re2.ReplaceAllString(name, `$1 $2`))
+	return names
+}
+
+var githubURL = regexp.MustCompile(`github\.com[/|:]([\w\.-]+)\/([\w\.-]+)\/?`)
+
+func getGitHubMeta(repo *packages.Repository) (*GitHubMeta, error) {
+	if repo == nil {
+		// no repo configured
+		return nil, nil
+	}
+
+	res := githubURL.FindAllStringSubmatch(*repo.URL, -1)
+	if len(res) == 0 {
+		return nil, fmt.Errorf("could not parse repo URL `%s`", *repo.URL)
+	}
+
+	client := github.GetClient()
+	api, _, err := client.Repositories.Get(util.ContextWithEntries(), res[0][1], strings.ReplaceAll(res[0][2], ".git", ""))
+	if err != nil {
+		return nil, err
+	}
+
+	return &GitHubMeta{
+		User:             api.GetOwner().GetLogin(),
+		Repo:             api.GetName(),
+		StargazersCount:  api.GetStargazersCount(),
+		Forks:            api.GetForksCount(),
+		SubscribersCount: api.GetSubscribersCount(),
+	}, nil
+}
+
+func getSRI(p *packages.Package) (string, error) {
+	jsonFile := path.Join(util.GetSRIsPath(), *p.Name, *p.Version+".json")
+
+	var j map[string]interface{}
+
+	data, err := ioutil.ReadFile(jsonFile)
+
+	if err != nil {
+		return "", nil
+	}
+
+	util.Check(json.Unmarshal(data, &j))
+
+	if p.Filename == nil {
+		return "", errors.New("SRI could not get converted to a string (nil filename)")
+	}
+	if str, ok := j[*p.Filename].(string); ok {
+		return str, nil
+	}
+	return "", errors.New("SRI could not get converted to a string")
+}
+
+// IndexPackage saves a package to the Algolia.
+func IndexPackage(p packages.Package, index *search.Index) error {
+	var author string
+	if p.Author != nil {
+		author = *p.Author
+	}
+
+	var license string
+	if p.License != nil {
+		license = *p.License
+	}
+
+	var filename string
+	if p.Filename != nil {
+		filename = *p.Filename
+	}
+
+	var homepage string
+	if p.Homepage != nil {
+		homepage = *p.Homepage
+	}
+
+	repository := p.Repository
+
+	github, githuberr := getGitHubMeta(repository)
+	if githuberr != nil {
+		fmt.Printf("%s", githuberr)
+		if strings.Contains(githuberr.Error(), "403 API rate limit") {
+			return fmt.Errorf("Fatal error `%s`", githuberr)
+		}
+	}
+
+	sri, srierr := getSRI(&p)
+	if srierr != nil {
+		fmt.Printf("%s", srierr)
+	}
+
+	searchEntry := SearchEntry{
+		Name:             *p.Name,
+		Filename:         filename,
+		Description:      *p.Description,
+		Keywords:         p.Keywords,
+		AlternativeNames: getAlternativeNames(*p.Name),
+		FileType:         strings.ReplaceAll(filepath.Ext(filename), ".", ""),
+		Github:           github,
+		ObjectID:         *p.Name,
+		Version:          *p.Version,
+		License:          license,
+		Homepage:         homepage,
+		Repository:       repository,
+		Author:           author,
+		OriginalName:     *p.Name,
+		Sri:              sri,
+	}
+
+	_, err := index.SaveObject(searchEntry)
+	return err
+}

--- a/cmd/algolia/main.go
+++ b/cmd/algolia/main.go
@@ -43,7 +43,7 @@ func main() {
 
 			for _, p := range j.Packages {
 				fmt.Printf("%s: ", *p.Name)
-				util.Check(algolia.IndexPackage(p, tmpIndex))
+				util.Check(algolia.IndexPackage(&p, tmpIndex))
 				fmt.Printf("Ok\n")
 			}
 			fmt.Printf("Ok\n")

--- a/cmd/algolia/main.go
+++ b/cmd/algolia/main.go
@@ -5,203 +5,21 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"path"
-	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/cdnjs/tools/algolia"
 	"github.com/cdnjs/tools/cloudstorage"
-	"github.com/cdnjs/tools/github"
 	"github.com/cdnjs/tools/packages"
 	"github.com/cdnjs/tools/sentry"
 	"github.com/cdnjs/tools/util"
-
-	algoliasearch "github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 )
-
-func init() {
-	sentry.Init()
-}
 
 // PackagesJSON is used to wrap around a slice of []Packages
 // when JSON unmarshalling.
 type PackagesJSON struct {
 	Packages []packages.Package `json:"packages"`
-}
-
-// SearchEntry represents an entry in the Algolia Search index.
-type SearchEntry struct {
-	Name             string               `json:"name"`
-	Filename         string               `json:"filename"`
-	Description      string               `json:"description"`
-	Version          string               `json:"version"`
-	Keywords         []string             `json:"keywords"`
-	AlternativeNames []string             `json:"alternativeNames"`
-	FileType         string               `json:"fileType"`
-	Github           *GitHubMeta          `json:"github"`
-	ObjectID         string               `json:"objectID"`
-	License          string               `json:"license"`
-	Homepage         string               `json:"homepage"`
-	Namespace        string               `json:"namespace,omitempty"`
-	Repository       *packages.Repository `json:"repository"`
-	Author           string               `json:"author"`
-	OriginalName     string               `json:"originalName"`
-	Sri              string               `json:"sri"`
-}
-
-// GitHubMeta contains metadata for a particular GitHub repository.
-type GitHubMeta struct {
-	User             string `json:"user"`
-	Repo             string `json:"repo"`
-	StargazersCount  int    `json:"stargazers_count"`
-	Forks            int    `json:"forks"`
-	SubscribersCount int    `json:"subscribers_count"`
-}
-
-func getPackagesBuffer() bytes.Buffer {
-	ctx := context.Background()
-
-	bkt, err := cloudstorage.GetAssetsBucket(ctx)
-	util.Check(err)
-
-	obj := bkt.Object("package.min.js")
-
-	r, err := obj.NewReader(ctx)
-	util.Check(err)
-	defer r.Close()
-
-	var b bytes.Buffer
-
-	_, copyerr := io.Copy(bufio.NewWriter(&b), r)
-	util.Check(copyerr)
-
-	return b
-}
-
-var (
-	re1 = regexp.MustCompile(`[^a-zA-Z]`)
-	re2 = regexp.MustCompile(`(^[^A-Z]*|[A-Z]*)([A-Z][^A-Z]+|$)`)
-)
-
-func getAlternativeNames(name string) []string {
-	names := make([]string, 0)
-	names = append(names, re1.ReplaceAllString(name, `$1 $2`))
-	names = append(names, re2.ReplaceAllString(name, `$1 $2`))
-	return names
-}
-
-var githubURL = regexp.MustCompile(`github\.com[/|:]([\w\.-]+)\/([\w\.-]+)\/?`)
-
-func getGitHubMeta(repo *packages.Repository) (*GitHubMeta, error) {
-	if repo == nil {
-		// no repo configured
-		return nil, nil
-	}
-
-	res := githubURL.FindAllStringSubmatch(*repo.URL, -1)
-	if len(res) == 0 {
-		return nil, fmt.Errorf("could not parse repo URL `%s`", *repo.URL)
-	}
-
-	client := github.GetClient()
-	api, _, err := client.Repositories.Get(util.ContextWithEntries(), res[0][1], strings.ReplaceAll(res[0][2], ".git", ""))
-	if err != nil {
-		return nil, err
-	}
-
-	return &GitHubMeta{
-		User:             api.GetOwner().GetLogin(),
-		Repo:             api.GetName(),
-		StargazersCount:  api.GetStargazersCount(),
-		Forks:            api.GetForksCount(),
-		SubscribersCount: api.GetSubscribersCount(),
-	}, nil
-}
-
-func getSRI(p *packages.Package) (string, error) {
-	jsonFile := path.Join(util.GetSRIsPath(), *p.Name, *p.Version+".json")
-
-	var j map[string]interface{}
-
-	data, err := ioutil.ReadFile(jsonFile)
-
-	if err != nil {
-		return "", nil
-	}
-
-	util.Check(json.Unmarshal(data, &j))
-
-	if p.Filename == nil {
-		return "", errors.New("SRI could not get converted to a string (nil filename)")
-	}
-	if str, ok := j[*p.Filename].(string); ok {
-		return str, nil
-	}
-	return "", errors.New("SRI could not get converted to a string")
-}
-
-func indexPackage(p packages.Package, index *algoliasearch.Index) error {
-	var author string
-	if p.Author != nil {
-		author = *p.Author
-	}
-
-	var license string
-	if p.License != nil {
-		license = *p.License
-	}
-
-	var filename string
-	if p.Filename != nil {
-		filename = *p.Filename
-	}
-
-	var homepage string
-	if p.Homepage != nil {
-		homepage = *p.Homepage
-	}
-
-	repository := p.Repository
-
-	github, githuberr := getGitHubMeta(repository)
-	if githuberr != nil {
-		fmt.Printf("%s", githuberr)
-		if strings.Contains(githuberr.Error(), "403 API rate limit") {
-			return fmt.Errorf("Fatal error `%s`", githuberr)
-		}
-	}
-
-	sri, srierr := getSRI(&p)
-	if srierr != nil {
-		fmt.Printf("%s", srierr)
-	}
-
-	searchEntry := SearchEntry{
-		Name:             *p.Name,
-		Filename:         filename,
-		Description:      *p.Description,
-		Keywords:         p.Keywords,
-		AlternativeNames: getAlternativeNames(*p.Name),
-		FileType:         strings.ReplaceAll(filepath.Ext(filename), ".", ""),
-		Github:           github,
-		ObjectID:         *p.Name,
-		Version:          *p.Version,
-		License:          license,
-		Homepage:         homepage,
-		Repository:       repository,
-		Author:           author,
-		OriginalName:     *p.Name,
-		Sri:              sri,
-	}
-
-	_, err := index.SaveObject(searchEntry)
-	return err
 }
 
 func main() {
@@ -225,7 +43,7 @@ func main() {
 
 			for _, p := range j.Packages {
 				fmt.Printf("%s: ", *p.Name)
-				util.Check(indexPackage(p, tmpIndex))
+				util.Check(algolia.IndexPackage(p, tmpIndex))
 				fmt.Printf("Ok\n")
 			}
 			fmt.Printf("Ok\n")
@@ -237,4 +55,24 @@ func main() {
 	default:
 		panic(fmt.Sprintf("unknown subcommand: `%s`", subcommand))
 	}
+}
+
+func getPackagesBuffer() bytes.Buffer {
+	ctx := context.Background()
+
+	bkt, err := cloudstorage.GetAssetsBucket(ctx)
+	util.Check(err)
+
+	obj := bkt.Object("package.min.js")
+
+	r, err := obj.NewReader(ctx)
+	util.Check(err)
+	defer r.Close()
+
+	var b bytes.Buffer
+
+	_, copyerr := io.Copy(bufio.NewWriter(&b), r)
+	util.Check(copyerr)
+
+	return b
 }

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cdnjs/tools/algolia"
+
 	"github.com/agnivade/levenshtein"
 	"github.com/blang/semver"
 	"github.com/cdnjs/tools/compress"
@@ -72,6 +74,9 @@ func main() {
 	if util.IsDebug() {
 		fmt.Printf("Running in debug mode (no-update=%t, no-pull=%t)\n", noUpdate, noPull)
 	}
+
+	// get algolia search index to update it in-place
+	index := algolia.GetProdIndex(algolia.GetClient())
 
 	// create channel to handle signals
 	c := make(chan os.Signal, 1)
@@ -146,6 +151,9 @@ func main() {
 			if versionsChanged || pkgChanged {
 				// Update aggregated package metadata for cdnjs API.
 				updateAggregatedMetadata(ctx, pckg, newAssets)
+
+				// update Algolia in-place
+				util.Check(algolia.IndexPackage(pckg, index))
 			}
 		}
 	}

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -151,7 +151,9 @@ func main() {
 			if versionsChanged || pkgChanged {
 				// Update aggregated package metadata for cdnjs API.
 				updateAggregatedMetadata(ctx, pckg, newAssets)
+			}
 
+			if pkgChanged {
 				// update Algolia in-place
 				util.Check(algolia.IndexPackage(pckg, index))
 			}


### PR DESCRIPTION
Addresses #202 .

- updates Algolia search index whenever a package is changed

If this works, we can remove the algolia updating service that runs every 12hr. If we run into any problems, this can be run to build the index from scratch.

