### PR TITLE
ignore CSS compression errors

### DIFF
--- a/compress/css.go
+++ b/compress/css.go
@@ -41,6 +41,10 @@ func CSS(ctx context.Context, file string) {
 
 	cmd := exec.Command(cleanCSS, args...)
 	util.Debugf(ctx, "compress: run %s\n", cmd)
-	out := util.CheckCmd(cmd.CombinedOutput())
-	util.Debugf(ctx, "%s\n", out)
+
+	if bytes, err := cmd.CombinedOutput(); err != nil {
+		util.Debugf(ctx, "Failed to compress CSS: %v\n", err)
+	} else {
+		util.Debugf(ctx, "%s\n", bytes)
+	}
 }

--- a/kv/tools.go
+++ b/kv/tools.go
@@ -105,7 +105,7 @@ func InsertFromDisk(logger *log.Logger, pckgs []string, metaOnly, srisOnly, file
 
 						if err != nil {
 							util.Infof(ctx, "p(%d/%d) v(%d/%d) failed to insert %s (%s): %s\n", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version, err)
-							sentry.NotifyError(fmt.Errorf("p(%d/%d) v(%d/%d) failed to insert %s (%s) to KV: %s\n", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version, err))
+							sentry.NotifyError(fmt.Errorf("p(%d/%d) v(%d/%d) failed to insert %s (%s) to KV: %s", i+1, len(pckgs), j+1, len(versions), *pckg.Name, version, err))
 							return
 						}
 					}


### PR DESCRIPTION
Fix #210 by ignoring CSS compression errors.

(I also removed a newline in `tools.go` since the linter was complaining).
