### PR TITLE
fix bug to check if minified js/css file exists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.26
+          version: v1.29

--- a/compress/css.go
+++ b/compress/css.go
@@ -22,7 +22,7 @@ func CSS(ctx context.Context, file string) {
 	outfile := file[0:len(file)-len(ext)] + ".min.css"
 
 	// compressed file already exists, ignore
-	if _, err := os.Stat(outfile); !os.IsNotExist(err) {
+	if _, err := os.Stat(outfile); err == nil {
 		util.Debugf(ctx, "compressed file already exists: %s\n", outfile)
 		return
 	}

--- a/compress/js.go
+++ b/compress/js.go
@@ -22,7 +22,7 @@ func Js(ctx context.Context, file string) {
 	outfile := file[0:len(file)-len(ext)] + ".min.js"
 
 	// compressed file already exists, ignore
-	if _, err := os.Stat(outfile); !os.IsNotExist(err) {
+	if _, err := os.Stat(outfile); err == nil {
 		util.Debugf(ctx, "compressed file already exists: %s\n", outfile)
 		return
 	}


### PR DESCRIPTION
the conditional was [incorrect](https://stackoverflow.com/questions/12518876/how-to-check-if-a-file-exists-in-go), and *not* the way one should check if a file exists in Go... it will never trigger so we were creating minified files whether they already existed or not...

this should fix [the issue](https://github.com/cdnjs/packages/issues/555)