### PR TITLE
Add optional tag to enable/disable optimization for js,css,png,jpg

### DIFF
--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -406,7 +406,7 @@ func optimizeAndMinify(ctx context.Context, version newVersionToCommit) {
 	wg.Add(len(files))
 
 	for w := 1; w <= cpuCount; w++ {
-		go compress.Worker(&wg, jobs)
+		go compress.Worker(&wg, jobs, version.pckg.Optimization)
 	}
 
 	for _, file := range files {

--- a/compress/worker.go
+++ b/compress/worker.go
@@ -15,30 +15,23 @@ type CompressJob struct {
 }
 
 func Worker(wg *sync.WaitGroup, jobs <-chan CompressJob, optim *packages.Optimization) {
-	// compress everything by default
-	jpg, png, js, css := true, true, true, true
-	if optim != nil {
-		jpg = optim.JPG == nil || *optim.JPG
-		png = optim.PNG == nil || *optim.PNG
-		js = optim.JS == nil || *optim.JS
-		css = optim.CSS == nil || *optim.CSS
-	}
+	defaultCompress := optim == nil // compress by default if optimization not specified
 	for j := range jobs {
 		switch path.Ext(j.File) {
 		case ".jpg", ".jpeg":
-			if jpg {
+			if defaultCompress || optim.Jpg() {
 				Jpeg(j.Ctx, path.Join(j.VersionPath, j.File))
 			}
 		case ".png":
-			if png {
+			if defaultCompress || optim.Png() {
 				Png(j.Ctx, path.Join(j.VersionPath, j.File))
 			}
 		case ".js":
-			if js {
+			if defaultCompress || optim.Js() {
 				Js(j.Ctx, path.Join(j.VersionPath, j.File))
 			}
 		case ".css":
-			if css {
+			if defaultCompress || optim.Css() {
 				CSS(j.Ctx, path.Join(j.VersionPath, j.File))
 			}
 		}

--- a/compress/worker.go
+++ b/compress/worker.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path"
 	"sync"
+
+	"github.com/cdnjs/tools/packages"
 )
 
 type CompressJob struct {
@@ -12,17 +14,33 @@ type CompressJob struct {
 	VersionPath string
 }
 
-func Worker(wg *sync.WaitGroup, jobs <-chan CompressJob) {
+func Worker(wg *sync.WaitGroup, jobs <-chan CompressJob, optim *packages.Optimization) {
+	// compress everything by default
+	jpg, png, js, css := true, true, true, true
+	if optim != nil {
+		jpg = optim.JPG == nil || *optim.JPG
+		png = optim.PNG == nil || *optim.PNG
+		js = optim.JS == nil || *optim.JS
+		css = optim.CSS == nil || *optim.CSS
+	}
 	for j := range jobs {
 		switch path.Ext(j.File) {
 		case ".jpg", ".jpeg":
-			Jpeg(j.Ctx, path.Join(j.VersionPath, j.File))
+			if jpg {
+				Jpeg(j.Ctx, path.Join(j.VersionPath, j.File))
+			}
 		case ".png":
-			Png(j.Ctx, path.Join(j.VersionPath, j.File))
+			if png {
+				Png(j.Ctx, path.Join(j.VersionPath, j.File))
+			}
 		case ".js":
-			Js(j.Ctx, path.Join(j.VersionPath, j.File))
+			if js {
+				Js(j.Ctx, path.Join(j.VersionPath, j.File))
+			}
 		case ".css":
-			CSS(j.Ctx, path.Join(j.VersionPath, j.File))
+			if css {
+				CSS(j.Ctx, path.Join(j.VersionPath, j.File))
+			}
 		}
 		wg.Done()
 	}

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -32,6 +32,15 @@ type Autoupdate struct {
 	FileMap []FileMap `json:"fileMap,omitempty"`
 }
 
+// Optimization is used to enable/disable optimization
+// for particular file types. By default, we will optimize all files.
+type Optimization struct {
+	JS  *bool `json:"js,omitempty"`
+	CSS *bool `json:"css,omitempty"`
+	PNG *bool `json:"png,omitempty"`
+	JPG *bool `json:"jpg,omitempty"`
+}
+
 // FileMap represents a number of files located
 // under a base path.
 type FileMap struct {
@@ -54,15 +63,16 @@ type Package struct {
 	versions []string        // cache list of versions
 
 	// human-readable properties
-	Authors     []Author    `json:"authors,omitempty"`
-	Autoupdate  *Autoupdate `json:"autoupdate,omitempty"`
-	Description *string     `json:"description,omitempty"`
-	Filename    *string     `json:"filename,omitempty"`
-	Homepage    *string     `json:"homepage,omitempty"`
-	Keywords    []string    `json:"keywords,omitempty"`
-	License     *string     `json:"license,omitempty"`
-	Name        *string     `json:"name,omitempty"`
-	Repository  *Repository `json:"repository,omitempty"`
+	Authors      []Author      `json:"authors,omitempty"`
+	Autoupdate   *Autoupdate   `json:"autoupdate,omitempty"`
+	Optimization *Optimization `json:"optimization,omitempty"`
+	Description  *string       `json:"description,omitempty"`
+	Filename     *string       `json:"filename,omitempty"`
+	Homepage     *string       `json:"homepage,omitempty"`
+	Keywords     []string      `json:"keywords,omitempty"`
+	License      *string       `json:"license,omitempty"`
+	Name         *string       `json:"name,omitempty"`
+	Repository   *Repository   `json:"repository,omitempty"`
 
 	// additional properties
 	Version *string `json:"version,omitempty"`

--- a/packages/packages.go
+++ b/packages/packages.go
@@ -41,6 +41,26 @@ type Optimization struct {
 	JPG *bool `json:"jpg,omitempty"`
 }
 
+// Js returns if we should optimize JavaScript files.
+func (o *Optimization) Js() bool {
+	return o.JS == nil || *o.JS
+}
+
+// Css returns if we should optimize CSS files.
+func (o *Optimization) Css() bool {
+	return o.CSS == nil || *o.CSS
+}
+
+// Png returns if we should optimize PNG files.
+func (o *Optimization) Png() bool {
+	return o.PNG == nil || *o.PNG
+}
+
+// Jpg returns if we should optimize JPG/JPEG files.
+func (o *Optimization) Jpg() bool {
+	return o.JPG == nil || *o.JPG
+}
+
 // FileMap represents a number of files located
 // under a base path.
 type FileMap struct {

--- a/packages/schema.go
+++ b/packages/schema.go
@@ -155,26 +155,21 @@ const humanReadableProperties = `
         "optimization": {
             "description": "Used to enable/disable optimization for particular file types. By default, optimization is enabled for all types.",
             "type": "object",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "js": {
-                        "type": "boolean"
-                    },
-                    "css": {
-                        "type": "boolean"
-                    },
-                    "png": {
-                        "type": "boolean"
-                    },
-                    "jpg": {
-                        "type": "boolean"
-                    }
+            "properties": {
+                "js": {
+                    "type": "boolean"
                 },
-                "additionalProperties": false
-            }
+                "css": {
+                    "type": "boolean"
+                },
+                "png": {
+                    "type": "boolean"
+                },
+                "jpg": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
         },
         "description": {
             "description": "The description of the library if it has been provided in the cdnjs package JSON file.",

--- a/packages/schema.go
+++ b/packages/schema.go
@@ -152,6 +152,30 @@ const humanReadableProperties = `
             ],
             "additionalProperties": false
         },
+        "optimization": {
+            "description": "Used to enable/disable optimization for particular file types. By default, optimization is enabled for all types.",
+            "type": "object",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "js": {
+                        "type": "boolean"
+                    },
+                    "css": {
+                        "type": "boolean"
+                    },
+                    "png": {
+                        "type": "boolean"
+                    },
+                    "jpg": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
         "description": {
             "description": "The description of the library if it has been provided in the cdnjs package JSON file.",
             "type": "string",

--- a/schema_human.json
+++ b/schema_human.json
@@ -79,26 +79,21 @@
         "optimization": {
             "description": "Used to enable/disable optimization for particular file types. By default, optimization is enabled for all types.",
             "type": "object",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "js": {
-                        "type": "boolean"
-                    },
-                    "css": {
-                        "type": "boolean"
-                    },
-                    "png": {
-                        "type": "boolean"
-                    },
-                    "jpg": {
-                        "type": "boolean"
-                    }
+            "properties": {
+                "js": {
+                    "type": "boolean"
                 },
-                "additionalProperties": false
-            }
+                "css": {
+                    "type": "boolean"
+                },
+                "png": {
+                    "type": "boolean"
+                },
+                "jpg": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
         },
         "description": {
             "description": "The description of the library if it has been provided in the cdnjs package JSON file.",

--- a/schema_human.json
+++ b/schema_human.json
@@ -76,6 +76,30 @@
             ],
             "additionalProperties": false
         },
+        "optimization": {
+            "description": "Used to enable/disable optimization for particular file types. By default, optimization is enabled for all types.",
+            "type": "object",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "js": {
+                        "type": "boolean"
+                    },
+                    "css": {
+                        "type": "boolean"
+                    },
+                    "png": {
+                        "type": "boolean"
+                    },
+                    "jpg": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
         "description": {
             "description": "The description of the library if it has been provided in the cdnjs package JSON file.",
             "type": "string",

--- a/schema_non_human.json
+++ b/schema_non_human.json
@@ -79,26 +79,21 @@
         "optimization": {
             "description": "Used to enable/disable optimization for particular file types. By default, optimization is enabled for all types.",
             "type": "object",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "js": {
-                        "type": "boolean"
-                    },
-                    "css": {
-                        "type": "boolean"
-                    },
-                    "png": {
-                        "type": "boolean"
-                    },
-                    "jpg": {
-                        "type": "boolean"
-                    }
+            "properties": {
+                "js": {
+                    "type": "boolean"
                 },
-                "additionalProperties": false
-            }
+                "css": {
+                    "type": "boolean"
+                },
+                "png": {
+                    "type": "boolean"
+                },
+                "jpg": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
         },
         "description": {
             "description": "The description of the library if it has been provided in the cdnjs package JSON file.",

--- a/schema_non_human.json
+++ b/schema_non_human.json
@@ -76,6 +76,30 @@
             ],
             "additionalProperties": false
         },
+        "optimization": {
+            "description": "Used to enable/disable optimization for particular file types. By default, optimization is enabled for all types.",
+            "type": "object",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "js": {
+                        "type": "boolean"
+                    },
+                    "css": {
+                        "type": "boolean"
+                    },
+                    "png": {
+                        "type": "boolean"
+                    },
+                    "jpg": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
         "description": {
             "description": "The description of the library if it has been provided in the cdnjs package JSON file.",
             "type": "string",

--- a/test/checker/schema_human_test.go
+++ b/test/checker/schema_human_test.go
@@ -339,6 +339,32 @@ func TestHumanReadableSchema(t *testing.T) {
 			filePath: "schema_tests/human_schema_tests/repository/invalid/type_npm.json",
 			errors:   []string{"repository.type: Does not match pattern '" + repositoryTypeRegex + "'"},
 		},
+		// optimization valid
+		{
+			filePath: "schema_tests/human_schema_tests/optimization/valid/all_fields.json",
+			valid:    true,
+		},
+		{
+			filePath: "schema_tests/human_schema_tests/optimization/valid/empty_optimization.json",
+			valid:    true,
+		},
+		{
+			filePath: "schema_tests/human_schema_tests/optimization/valid/js_only.json",
+			valid:    true,
+		},
+		{
+			filePath: "schema_tests/human_schema_tests/optimization/valid/no_optimization.json",
+			valid:    true,
+		},
+		// optimization invalid
+		{
+			filePath: "schema_tests/human_schema_tests/optimization/invalid/invalid_key.json",
+			errors:   []string{"optimization: Additional property happy is not allowed"},
+		},
+		{
+			filePath: "schema_tests/human_schema_tests/optimization/invalid/not_boolean.json",
+			errors:   []string{"optimization.js: Invalid type. Expected: boolean, given: string"},
+		},
 	}
 
 	runSchemaTestCases(t, packages.HumanReadableSchema, cases)

--- a/test/checker/schema_tests/human_schema_tests/optimization/invalid/invalid_key.json
+++ b/test/checker/schema_tests/human_schema_tests/optimization/invalid/invalid_key.json
@@ -32,9 +32,6 @@
         ]
     },
     "optimization": {
-        "js": true,
-        "css": true,
-        "png": true,
-        "jpg": true
+        "happy": true
     }
 }

--- a/test/checker/schema_tests/human_schema_tests/optimization/invalid/not_boolean.json
+++ b/test/checker/schema_tests/human_schema_tests/optimization/invalid/not_boolean.json
@@ -32,9 +32,6 @@
         ]
     },
     "optimization": {
-        "js": true,
-        "css": true,
-        "png": true,
-        "jpg": true
+        "js": "hello"
     }
 }

--- a/test/checker/schema_tests/human_schema_tests/optimization/valid/all_fields.json
+++ b/test/checker/schema_tests/human_schema_tests/optimization/valid/all_fields.json
@@ -32,9 +32,9 @@
         ]
     },
     "optimization": {
-        "js": true,
+        "js": false,
         "css": true,
-        "png": true,
+        "png": false,
         "jpg": true
     }
 }

--- a/test/checker/schema_tests/human_schema_tests/optimization/valid/empty_optimization.json
+++ b/test/checker/schema_tests/human_schema_tests/optimization/valid/empty_optimization.json
@@ -32,9 +32,5 @@
         ]
     },
     "optimization": {
-        "js": true,
-        "css": true,
-        "png": true,
-        "jpg": true
     }
 }

--- a/test/checker/schema_tests/human_schema_tests/optimization/valid/js_only.json
+++ b/test/checker/schema_tests/human_schema_tests/optimization/valid/js_only.json
@@ -32,9 +32,6 @@
         ]
     },
     "optimization": {
-        "js": true,
-        "css": true,
-        "png": true,
-        "jpg": true
+        "js": false
     }
 }

--- a/test/checker/schema_tests/human_schema_tests/optimization/valid/no_optimization.json
+++ b/test/checker/schema_tests/human_schema_tests/optimization/valid/no_optimization.json
@@ -30,11 +30,5 @@
                 ]
             }
         ]
-    },
-    "optimization": {
-        "js": true,
-        "css": true,
-        "png": true,
-        "jpg": true
     }
 }


### PR DESCRIPTION
- (note that jpg includes both `.jpg` and `.jpeg`)
- Fix for[ preventing .min.js from being generated](https://github.com/cdnjs/packages/issues/555#issuecomment-749667949)