### PR TITLE
Don't validate against schema when inflating packages

### DIFF
--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -189,7 +189,7 @@ func parseHumanPackage(ctx context.Context, pckgPath string, noPathValidation bo
 	}
 
 	// parse package JSON
-	pckg, readerr := packages.ReadHumanJSONBytes(ctx, pckgPath, bytes)
+	pckg, readerr := packages.ReadHumanJSONBytes(ctx, pckgPath, bytes, true)
 	if readerr != nil {
 		if invalidHumanErr, ok := readerr.(packages.InvalidSchemaError); ok {
 			// output all schema errors

--- a/packages/parse.go
+++ b/packages/parse.go
@@ -13,17 +13,19 @@ import (
 
 // Unmarshals the human-readable JSON into a *Package,
 // setting the legacy `author` field if needed.
-func ReadHumanJSONBytes(ctx context.Context, file string, bytes []byte) (*Package, error) {
-	// validate against human readable JSON schema
-	res, err := HumanReadableSchema.Validate(gojsonschema.NewBytesLoader(bytes))
-	if err != nil {
-		// invalid JSON
-		return nil, errors.Wrapf(err, "failed to parse %s", file)
-	}
+func ReadHumanJSONBytes(ctx context.Context, file string, bytes []byte, validateSchema bool) (*Package, error) {
+	if validateSchema {
+		// validate against human readable JSON schema
+		res, err := HumanReadableSchema.Validate(gojsonschema.NewBytesLoader(bytes))
+		if err != nil {
+			// invalid JSON
+			return nil, errors.Wrapf(err, "failed to parse %s", file)
+		}
 
-	if !res.Valid() {
-		// invalid schema, so return result and custom error
-		return nil, InvalidSchemaError{res}
+		if !res.Valid() {
+			// invalid schema, so return result and custom error
+			return nil, InvalidSchemaError{res}
+		}
 	}
 
 	// unmarshal JSON into package

--- a/packages/repo.go
+++ b/packages/repo.go
@@ -75,7 +75,7 @@ func inflatePackages(src *os.File) ([]*Package, error) {
 				return nil, errors.Wrap(err, "could not read file")
 			}
 
-			pkg, err := ReadHumanJSONBytes(ctx, f.Name, bytes)
+			pkg, err := ReadHumanJSONBytes(ctx, f.Name, bytes, false)
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not parse Package: %s", f.Name)
 			}


### PR DESCRIPTION
- we will ensure package JSON files are valid against the human-schema before merging with cdnjs/packages
- we can't validate using this schema when inflating because some packages have old fields (ex. autoupdate) that are now required in the new schema