### PR TITLE
Remove empty versions from aggregated metadata

### DIFF
--- a/packages/packages.go
+++ b/packages/packages.go
@@ -148,6 +148,16 @@ func (p *Package) UpdateVersion(name string, newAsset Asset) {
 	}
 }
 
+func (p *Package) RemoveVersion(name string) {
+	newAssets := make([]Asset, 0)
+	for _, asset := range p.Assets {
+		if asset.Version != name {
+			newAssets = append(newAssets, asset)
+		}
+	}
+	p.Assets = newAssets
+}
+
 // NpmFilesFrom lists files that match the npm glob pattern in the `base` directory
 // Returns a struct that represent the move semantics
 func (p *Package) NpmFilesFrom(base string) []NpmFileMoveOp {


### PR DESCRIPTION
If we see that a version is empty, we ensure it is not part of the aggregated metadata. 
If it is, we remove it from the aggregated metadata.

That way, the API will not see empty versions at all.
