### PR TITLE
Algolia: fetch existing versions from aggregated metadata

### DIFF
--- a/functions/algolia-pump/main.go
+++ b/functions/algolia-pump/main.go
@@ -29,13 +29,13 @@ var (
 	CF_ACCOUNT_ID = os.Getenv("CF_ACCOUNT_ID")
 )
 
-func getExistingVersions(p *packages.Package) ([]string, error) {
+func getExistingVersionsFromAggregatedMetadata(p *packages.Package) ([]string, error) {
 	cfapi, err := cloudflare.NewWithAPIToken(KV_TOKEN, cloudflare.UsingAccount(CF_ACCOUNT_ID))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create cloudflare API client")
 	}
 
-	versions, err := kv.GetVersions(cfapi, *p.Name)
+	versions, err := kv.GetVersionsFromAggregatedMetadata(cfapi, *p.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get verions")
 	}
@@ -63,7 +63,7 @@ func Invoke(ctx context.Context, e gcp.GCSEvent) error {
 		return fmt.Errorf("could not decode config: %v", err)
 	}
 	// update package version with latest
-	versions, err := getExistingVersions(pkg)
+	versions, err := getExistingVersionsFromAggregatedMetadata(pkg)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve existing versions: %s", err)
 	}

--- a/kv/aggregate.go
+++ b/kv/aggregate.go
@@ -13,6 +13,35 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 )
 
+// GetVersionsFromAggregatedMetadata gets the list version for a particular package
+// using the aggregated metadata endpoint.
+//
+// The aggregated metadata will only contain non-empty versions, so this is useful
+// for updating Algolia.
+func GetVersionsFromAggregatedMetadata(api *cloudflare.API, pckgname string) ([]string, error) {
+	aggPkg, err := getAggregatedMetadata(api, pckgname)
+	if err != nil {
+		switch err.(type) {
+		case KeyNotFoundError:
+			{
+				return nil, nil
+			}
+		default:
+			{
+				// api error
+				return nil, err
+			}
+		}
+	}
+
+	var versions []string
+	for _, asset := range aggPkg.Assets {
+		versions = append(versions, asset.Version)
+	}
+
+	return versions, nil
+}
+
 // RemoveVersionFromAggregatedMetadata will remove a particular version from
 // a package's KV entry for aggregated metadata if it exists.
 // This is useful for removing empty versions with no files.


### PR DESCRIPTION
We will use the versions from aggregated metadata to determine the latest version, meaning we will not consider any empty versions (since only non-empty versions are in aggregated metadata)