### PR TITLE
checker: show files includes woff2

### DIFF
--- a/cmd/checker/main.go
+++ b/cmd/checker/main.go
@@ -212,7 +212,7 @@ func filewalker(basedir string, files *[]string) filepath.WalkFunc {
 			return errors.Wrap(err, "failed to walk fs")
 		}
 		ext := filepath.Ext(path)
-		if ext == ".gz" {
+		if ext == ".gz" || ext == ".woff2" {
 			path = strings.ReplaceAll(path, ".gz", "")
 			path = strings.ReplaceAll(path, basedir+"/", "")
 			*files = append(*files, path)


### PR DESCRIPTION
We show the files by processing the files, compressing them and then listing all .gz files. However .woff2 isn't compress and is filtered out. This change explictily includes .woff2 files in the list.