### PR TITLE
process-version: pin version JS minifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "clean-css-cli": "^4.1.11",
-    "uglify-es": "^3.3.10",
-    "uglify-js": "^3.4.6"
+    "uglify-es": "3.3.10",
+    "uglify-js": "3.15.4"
   }
 }


### PR DESCRIPTION
In production will downgrades uglify-js from 3.17.4 to 3.15.4 to be consistent.